### PR TITLE
Promises Support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,6 +22,55 @@ If you go to the original project and modify the code there, your changes will b
 
 To run examples/tests install Mocha `$ npm install -g mocha` and run `$ mocha you-file-name.js`:
 
+## Using Promises
+
+Using promises is *optional*.
+
+Install the bluebird promises library:
+
+    npm install bluebird
+
+An example of using oauth-libre with Promises:
+
+```
+var OAuth2 = require('oauth-libre').PromiseOAuth2;
+
+var clientId = '';
+var clientSecret = '';
+
+// Fill these in:
+var user = 'USER';
+var personalAccessToken = 'PERSONAL_ACCESS_TOKEN';
+
+var baseSiteUrl = 'https://' + user + ':' + personalAccessToken + '@api.github.com/';
+var authorizePath = 'oauth2/authorize';
+var accessTokenPath = 'oauth2/access_token';
+var customHeaders = null;
+
+var oauth2 = new OAuth2(
+  clientId, clientSecret, baseSiteUrl, authorizePath, accessTokenPath, customHeaders
+);
+
+var url = 'https://api.github.com/users/' + user + '/received_events';
+oauth2
+  .get(url, personalAccessToken)
+  .then(jsonParse)
+  .then(function(json) {
+    for (var i = 0; i < json.length; i += 1) {
+      console.log(json[i]['id'] + ': ' + json[i].type);
+    }
+  })
+  .catch(function(err) {
+    console.log('Error: ' + err);
+  });
+
+function jsonParse(data) {
+  return JSON.parse(data);
+}
+```
+
+Note that in the first line you must explicitly import OAuth2 with promises.
+
 ## OAuth1.0
 
 ```javascript

--- a/examples/github-oauth2.js
+++ b/examples/github-oauth2.js
@@ -1,0 +1,34 @@
+var OAuth2 = require('../index').PromiseOAuth2;
+
+var clientId = '';
+var clientSecret = '';
+
+// Fill these in:
+var user = 'USER';
+var personalAccessToken = 'PERSONAL_ACCESS_TOKEN';
+
+var baseSiteUrl = 'https://' + user + ':' + personalAccessToken + '@api.github.com/';
+var authorizePath = 'oauth2/authorize';
+var accessTokenPath = 'oauth2/access_token';
+var customHeaders = null;
+
+var oauth2 = new OAuth2(
+  clientId, clientSecret, baseSiteUrl, authorizePath, accessTokenPath, customHeaders
+);
+
+var url = 'https://api.github.com/users/' + user + '/received_events';
+oauth2
+  .get(url, personalAccessToken)
+  .then(jsonParse)
+  .then(function(json) {
+    for (var i = 0; i < json.length; i += 1) {
+      console.log(json[i]['id'] + ': ' + json[i].type);
+    }
+  })
+  .catch(function(err) {
+    console.log('Error: ' + err);
+  });
+
+function jsonParse(data) {
+  return JSON.parse(data);
+}

--- a/examples/promise-twitter-example.js
+++ b/examples/promise-twitter-example.js
@@ -1,0 +1,106 @@
+/*
+*
+* This is an example of the original Twitter OAuth 1
+* example, ported over to use the promise library.
+*
+* NOTE: Express should be installed (included here for ease of use,
+*     if you're not using Express, this can be easily done
+*     through Node's http.createSever() call.
+*
+*/
+
+var http = require('http');
+var oauth = require('../lib/oauth-promise').OAuth;
+var express = require('express');
+
+const callbackURL = 'http://localhost:5000/oauth_callback';
+const yourConsumerKey = 'INSERT YOUR CONSUMER KEY HERE';
+const yourConsumerSecret = 'INSERT YOUR CONSUMER SECRET KEY HERE';
+
+var reqTokenSecrets = {}; // Hash that contains the req_token:req_token_secret key vals
+
+
+/*
+ STEP 1 - init the OAuth Client!
+ */
+var oa = new oauth(
+  'https://api.twitter.com/oauth/request_token',
+  'https://api.twitter.com/oauth/access_token',
+  yourConsumerKey,            // CONSUMER KEY
+  yourConsumerSecret,         // CONSUMER SECRET
+  '1.0',
+  callbackURL,
+  'HMAC-SHA1'
+);
+
+var app = express();
+app.get('/', function(req, res){
+
+
+  // STEP 2: Ask twitter for a signed request token
+
+  // oAuthToken/Secret used for this this handshake process
+  var requestTokenPromise = oa.getOAuthRequestToken();
+
+
+  /*
+    Promise returns data array in the format:
+
+    data[0]: oauth_token
+    data[1]: oauth_token_secret
+    data[2]: results
+
+   */
+  requestTokenPromise.then(function(data){
+
+    // Extract data
+    var oauthToken = data[0];
+    var oauthTokenSecret = data[1];
+
+    // Get the secret oauth request token
+    reqTokenSecrets[oauthToken] = oauthTokenSecret;
+
+    // Redirect user to Twitter Auth
+    var redirectURL = 'https://api.twitter.com/oauth/authorize'+'?oauth_token='+oauthToken;
+    res.redirect(redirectURL);
+
+  });
+
+});
+
+
+app.get('/oauth_callback', function(req, res){
+
+  // This is where we get the oauth  token, oauth verifier, and give the oauth token secret as well
+
+  /**
+   * STEP 4: Get the access token and access token secret - finally what we need! :)
+   */
+  var accessTokenPromise = oa.getOAuthAccessToken(req.query.oauth_token,
+                                                  reqTokenSecrets[req.query.oauth_token],
+                                                  req.query.oauth_verifier);
+
+  /*
+    Similar to access token:
+    data[0]: access token
+    data[1]: access token secret
+    data[2]: results
+   */
+  accessTokenPromise.then(function(data){
+
+    var accessToken = data[0];
+    var accessTokenSecret = data[1];
+    var results = data[2];
+
+
+      // here we get access token, access token secret - this is what we use to access the
+      // user's Twitter resources, you want to store this!
+      res.send('Acc token: ' + accessToken  + ' \nAcc token secret: ' + accessTokenSecret);
+    });
+
+  });
+
+app.listen(5000, function(){
+  console.log('Listening on port 5000');
+});
+

--- a/examples/twitter-oauth-promises.js
+++ b/examples/twitter-oauth-promises.js
@@ -1,0 +1,40 @@
+var OAuth = require('../index').PromiseOAuth;
+
+// Setting up the OAuth client
+var requestUrl = 'https://api.twitter.com/oauth/request_token';
+var accessUrl = 'https://api.twitter.com/oauth/access_token';
+var version = '1.0';
+var authorizeCallback = 'oob';
+var signatureMethod = 'HMAC-SHA1';
+var nonceSize = null;
+var customHeaders = null;
+
+// Go to https://dev.twitter.com/oauth/overview/application-owner-access-tokens
+// to fill these in:
+var consumerKey = 'your consumer key';
+var consumerSecret = 'your consumer secret';
+
+var client = new OAuth(
+  requestUrl, accessUrl,
+  consumerKey, consumerSecret,
+  version,
+  authorizeCallback,
+  signatureMethod,
+  nonceSize,
+  customHeaders
+);
+
+// Making a request to the API
+var url = 'https://api.twitter.com/1.1/statuses/home_timeline.json';
+
+// Go to https://dev.twitter.com/oauth/overview/application-owner-access-tokens
+// to fill these in:
+var accessToken = 'your access token';
+var accessTokenSecret = 'your access token secret';
+
+client.get(url, accessToken, accessTokenSecret).then(function(data, response) {
+  console.log('Data: ' + data);
+  console.log('Response: ' + response);
+}).catch(function(err) {
+  console.log('Error: ' + error);
+});

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 exports.OAuth = require("./lib/oauth").OAuth;
 exports.OAuthEcho = require("./lib/oauth").OAuthEcho;
 exports.OAuth2 = require("./lib/oauth2").OAuth2;
+exports.PromiseOAuth2 = require("./lib/oauth2-promise").OAuth2;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 exports.OAuth = require("./lib/oauth").OAuth;
 exports.OAuthEcho = require("./lib/oauth").OAuthEcho;
 exports.OAuth2 = require("./lib/oauth2").OAuth2;
+exports.PromiseOAuth = require("./lib/oauth-promise").OAuth;
 exports.PromiseOAuth2 = require("./lib/oauth2-promise").OAuth2;

--- a/lib/oauth-promise.js
+++ b/lib/oauth-promise.js
@@ -3,7 +3,7 @@ var _OAuth = require('./oauth').OAuth;
 
 var OAuth = function(requestUrl, accessUrl, consumerKey, consumerSecret, version, authorize_callback, signatureMethod, nonceSize, customHeaders) {
   this._oa = new _OAuth(requestUrl, accessUrl, consumerKey, consumerSecret, version, authorize_callback, signatureMethod, nonceSize, customHeaders);
-  this._oa.prototype = Promise.promisifyAll(_OAuth.prototype);
+  this._oa.prototype = Promise.promisifyAll(_OAuth.prototype, { multiArgs: true });
 };
 
 // Promisifed public API for OAuth

--- a/lib/oauth-promise.js
+++ b/lib/oauth-promise.js
@@ -13,8 +13,7 @@ var delegatedPromiseMethods = [
   'getOAuthAccessToken',
   'getOAuthRequestToken',
   'post',
-  'put',
-  'signUrl'
+  'put'
 ];
 
 delegatedPromiseMethods.forEach(asyncDelegate);
@@ -24,6 +23,7 @@ var delegatedMethods = [
   'authHeader',
   'getProtectedResource',
   'setClientOptions',
+  'signUrl',
 
   // Required for testing
   '_buildAuthorizationHeaders',

--- a/lib/oauth-promise.js
+++ b/lib/oauth-promise.js
@@ -1,0 +1,58 @@
+var Promise = require('bluebird');
+var _OAuth = require('./oauth').OAuth;
+
+var OAuth = function(requestUrl, accessUrl, consumerKey, consumerSecret, version, authorize_callback, signatureMethod, nonceSize, customHeaders) {
+  this._oa = new _OAuth(requestUrl, accessUrl, consumerKey, consumerSecret, version, authorize_callback, signatureMethod, nonceSize, customHeaders);
+  this._oa.prototype = Promise.promisifyAll(_OAuth.prototype);
+};
+
+// Promisifed public API for OAuth
+var delegatedPromiseMethods = [
+  'delete',
+  'get',
+  'getOAuthAccessToken',
+  'getOAuthRequestToken',
+  'post',
+  'put',
+  'signUrl'
+];
+
+delegatedPromiseMethods.forEach(asyncDelegate);
+
+// delegates PromiseOAuth.methodName to OAuth.methodName
+var delegatedMethods = [
+  'authHeader',
+  'getProtectedResource',
+  'setClientOptions',
+
+  // Required for testing
+  '_buildAuthorizationHeaders',
+  '_createSignature',
+  '_createSignatureBase',
+  '_encodeData',
+  '_getNonce',
+  '_getSignature',
+  '_getTimestamp',
+  '_makeArrayOfArgumentsHash',
+  '_normaliseRequestParams',
+  '_normalizeUrl',
+  '_performSecureRequest',
+  '_prepareParameters',
+  '_sortRequestParams'
+];
+
+delegatedMethods.forEach(delegate);
+
+function delegate(methodName) {
+  OAuth.prototype[methodName] = function() {
+    return this._oa[methodName].apply(this._oa, arguments);
+  };
+}
+
+function asyncDelegate(methodName) {
+  OAuth.prototype[methodName] = function() {
+    return this._oa[methodName + 'Async'].apply(this._oa, arguments);
+  };
+}
+
+exports.OAuth = OAuth;

--- a/lib/oauth-promise.js
+++ b/lib/oauth-promise.js
@@ -33,6 +33,7 @@ var delegatedMethods = [
   '_getNonce',
   '_getSignature',
   '_getTimestamp',
+  '_isParameterNameAnOAuthParameter',
   '_makeArrayOfArgumentsHash',
   '_normaliseRequestParams',
   '_normalizeUrl',

--- a/lib/oauth2-promise.js
+++ b/lib/oauth2-promise.js
@@ -1,0 +1,38 @@
+var Promise = require('bluebird');
+var _OAuth2 = require('./oauth2').OAuth2;
+
+var OAuth2 = function(clientId, clientSecret, baseSite, authorizePath, accessTokenPath, customHeaders) {
+  this._oa = new _OAuth2(clientId, clientSecret, baseSite, authorizePath, accessTokenPath, customHeaders);
+  this._oa.prototype = Promise.promisifyAll(_OAuth2.prototype);
+};
+
+// Promisfied public API for OAuth2
+OAuth2.prototype.getOAuthAccessToken = function() {
+  return this._oa.getOAuthAccessTokenAsync.apply(this._oa, arguments);
+};
+
+OAuth2.prototype.get = function() {
+  return this._oa.getAsync.apply(this._oa, arguments);
+};
+
+// delegates PromiseOAuth2.methodName to OAuth2.methodName
+var delegatedMethods = [
+  'buildAuthHeader',
+  'getAuthorizeUrl',
+  'setAuthMethod',
+  'useAuthorizationHeaderforGET',
+
+  // Required for testing
+  '_executeRequest',
+  '_request'
+];
+
+delegatedMethods.forEach(delegate);
+
+function delegate(methodName) {
+  OAuth2.prototype[methodName] = function() {
+    return this._oa[methodName].apply(this._oa, arguments);
+  };
+}
+
+exports.OAuth2 = OAuth2;

--- a/lib/oauth2-promise.js
+++ b/lib/oauth2-promise.js
@@ -12,7 +12,9 @@ OAuth2.prototype.getOAuthAccessToken = function() {
 };
 
 OAuth2.prototype.get = function() {
-  return this._oa.getAsync.apply(this._oa, arguments);
+  return this._oa.getAsync.apply(this._oa, arguments).then(function(res) {
+    return res[0];
+  });
 };
 
 // delegates PromiseOAuth2.methodName to OAuth2.methodName

--- a/lib/oauth2-promise.js
+++ b/lib/oauth2-promise.js
@@ -3,7 +3,7 @@ var _OAuth2 = require('./oauth2').OAuth2;
 
 var OAuth2 = function(clientId, clientSecret, baseSite, authorizePath, accessTokenPath, customHeaders) {
   this._oa = new _OAuth2(clientId, clientSecret, baseSite, authorizePath, accessTokenPath, customHeaders);
-  this._oa.prototype = Promise.promisifyAll(_OAuth2.prototype);
+  this._oa.prototype = Promise.promisifyAll(_OAuth2.prototype, { multiArgs: true });
 };
 
 // Promisfied public API for OAuth2

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
       "url": "https://github.com/omouse/node-oauth-libre/raw/master/LICENSE.mit"
     }
   ],
-  "dependencies": {
+  "optionalDependencies": {
     "bluebird": "^3.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
         }
     ]
     "repository": { "type":"git", "url":"http://github.com/omouse/node-oauth.git" },
-    "devDependencies": {
+  "dependencies": {
+    "bluebird": "^3.3.4"
+  },
+  "devDependencies": {
     "vows": "0.5.x"
   }
 , "scripts": {

--- a/tests/oauth2promise-tests.js
+++ b/tests/oauth2promise-tests.js
@@ -1,0 +1,290 @@
+var vows = require('vows'),
+    assert = require('assert'),
+    DummyResponse= require('./shared').DummyResponse,
+    DummyRequest= require('./shared').DummyRequest,
+    https = require('https'),
+    OAuth2= require('../lib/oauth2-promise').OAuth2,
+    url = require('url');
+
+vows.describe('OAuth2-Promise').addBatch({
+    'Given an OAuth2 instance with clientId and clientSecret, ': {
+      topic: new OAuth2("clientId", "clientSecret"),
+      'When dealing with the response from the OP': {
+        'we should treat a 201 response as a success': function(oa) {
+          var callbackCalled= false;
+          var http_library= {
+            request: function() {
+              return new DummyRequest(new DummyResponse(201));
+            }
+          };
+          oa._executeRequest( http_library, {}, null, function(err, result, response) {
+            callbackCalled= true;
+            assert.equal(err, null);
+          });
+          assert.ok(callbackCalled);
+        },
+        'we should treat a 200 response as a success': function(oa) {
+          var callbackCalled= false;
+          var http_library= {
+            request: function() {
+              return new DummyRequest(new DummyResponse(200));
+            }
+          };
+          oa._executeRequest( http_library, {}, null, function(err, result, response) {
+            callbackCalled= true;
+            assert.equal(err, null);
+          });
+          assert.ok(callbackCalled);
+        }
+      },
+      'When handling the access token response': {
+        'we should correctly extract the token if received as form-data': function (oa) {
+            oa._request= function( method, url, fo, bar, bleh, callback) {
+              callback(null, "access_token=access&refresh_token=refresh");
+            };
+            oa.getOAuthAccessToken("", {}, function(error, access_token, refresh_token) {
+              assert.equal( access_token, "access");
+              assert.equal( refresh_token, "refresh");
+            });
+        },
+        'we should not include access token in both querystring and headers (favours headers if specified)': function (oa) {
+            oa._request = new OAuth2("clientId", "clientSecret")._request.bind(oa);
+            oa._executeRequest= function( http_library, options, post_body, callback) {
+              callback(null, url.parse(options.path, true).query, options.headers);
+            };
+
+            oa._request("GET", "http://foo/", {"Authorization":"Bearer BadNews"}, null, "accessx",  function(error, query, headers) {
+              assert.ok( !('access_token' in query), "access_token also in query");
+              assert.ok( 'Authorization' in headers, "Authorization not in headers");
+            });
+        },
+        'we should include access token in the querystring if no Authorization header present to override it': function (oa) {
+           oa._request = new OAuth2("clientId", "clientSecret")._request.bind(oa);
+           oa._executeRequest= function( http_library, options, post_body, callback) {
+             callback(null, url.parse(options.path, true).query, options.headers);
+           };
+           oa._request("GET", "http://foo/", {}, null, "access",  function(error, query, headers) {
+             assert.ok( 'access_token' in query, "access_token not present in query");
+              assert.ok( !('Authorization' in headers), "Authorization in headers");
+            });
+        },
+        'we should correctly extract the token if received as a JSON literal': function (oa) {
+          oa._request= function(method, url, headers, post_body, access_token, callback) {
+            callback(null, '{"access_token":"access","refresh_token":"refresh"}');
+          };
+          oa.getOAuthAccessToken("", {}, function(error, access_token, refresh_token) {
+            assert.equal( access_token, "access");
+            assert.equal( refresh_token, "refresh");
+          });
+        },
+        'we should return the received data to the calling method': function (oa) {
+          oa._request= function(method, url, headers, post_body, access_token, callback) {
+            callback(null, '{"access_token":"access","refresh_token":"refresh","extra_1":1, "extra_2":"foo"}');
+          };
+          oa.getOAuthAccessToken("", {}, function(error, access_token, refresh_token, results) {
+            assert.equal( access_token, "access");
+            assert.equal( refresh_token, "refresh");
+            assert.isNotNull( results );
+            assert.equal( results.extra_1, 1);
+            assert.equal( results.extra_2, "foo");
+          });
+        }
+      },
+      'When no grant_type parameter is specified': {
+        'we should pass the value of the code argument as the code parameter': function(oa) {
+          oa._request= function(method, url, headers, post_body, access_token, callback) {
+            assert.isTrue( post_body.indexOf("code=xsds23") != -1 );
+          };
+          oa.getOAuthAccessToken("xsds23", {} );
+        }
+      },
+      'When an invalid grant_type parameter is specified': {
+        'we should pass the value of the code argument as the code parameter': function(oa) {
+          oa._request= function(method, url, headers, post_body, access_token, callback) {
+            assert.isTrue( post_body.indexOf("code=xsds23") != -1 );
+          };
+          oa.getOAuthAccessToken("xsds23", {grant_type:"refresh_toucan"} );
+        }
+      },
+      'When a grant_type parameter of value "refresh_token" is specified': {
+        'we should pass the value of the code argument as the refresh_token parameter, should pass a grant_type parameter, but shouldn\'t pass a code parameter' : function(oa) {
+          oa._request= function(method, url, headers, post_body, access_token, callback) {
+            assert.isTrue( post_body.indexOf("refresh_token=sdsds2") != -1 );
+            assert.isTrue( post_body.indexOf("grant_type=refresh_token") != -1 );
+            assert.isTrue( post_body.indexOf("code=") == -1 );
+          };
+          oa.getOAuthAccessToken("sdsds2", {grant_type:"refresh_token"} );
+        }
+      },
+      'When we use the authorization header': {
+        'and call get with the default authorization method': {
+          'we should pass the authorization header with Bearer method and value of the access_token, _request should be passed a null access_token' : function(oa) {
+            oa._request= function(method, url, headers, post_body, access_token, callback) {
+              assert.equal(headers["Authorization"], "Bearer abcd5");
+              assert.isNull( access_token );
+            };
+            oa.useAuthorizationHeaderforGET(true);
+            oa.get("", "abcd5");
+          }
+        },
+        'and call get with the authorization method set to Basic': {
+          'we should pass the authorization header with Basic method and value of the access_token, _request should be passed a null access_token' : function(oa) {
+            oa._request= function(method, url, headers, post_body, access_token, callback) {
+              assert.equal(headers["Authorization"], "Basic cdg2");
+              assert.isNull( access_token );
+            };
+            oa.useAuthorizationHeaderforGET(true);
+            oa.setAuthMethod("Basic");
+            oa.get("", "cdg2");
+          }
+        }
+      },
+      'When we do not use the authorization header': {
+        'and call get': {
+          'we should pass NOT provide an authorization header and the access_token should be being passed to _request' : function(oa) {
+            oa._request= function(method, url, headers, post_body, access_token, callback) {
+              assert.isUndefined(headers["Authorization"]);
+              assert.equal( access_token, "abcd5" );
+            };
+            oa.useAuthorizationHeaderforGET(false);
+            oa.get("", "abcd5");
+          }
+        }
+      }
+    },
+    'Given an OAuth2 instance with clientId, clientSecret and customHeaders': {
+      topic: new OAuth2("clientId", "clientSecret", undefined, undefined, undefined,
+          { 'SomeHeader': '123' }),
+      'When GETing': {
+        'we should see the custom headers mixed into headers property in options passed to http-library' : function(oa) {
+          oa._executeRequest= function( http_library, options, callback ) {
+            assert.equal(options.headers["SomeHeader"], "123");
+          };
+          oa.get("", {});
+        },
+      }
+    },
+    'Given an OAuth2 instance with a clientId and clientSecret': {
+      topic: new OAuth2("clientId", "clientSecret"),
+        'When POSTing': {
+          'we should see a given string being sent to the request' : function(oa) {
+            var bodyWritten= false;
+            oa._oa._chooseHttpLibrary= function() {
+              return {
+                request: function(options) {
+                  assert.equal(options.headers["Content-Type"], "text/plain");
+                  assert.equal(options.headers["Content-Length"], 26);
+                  assert.equal(options.method, "POST");
+                  return  {
+                    end: function() {},
+                    on: function() {},
+                    write: function(body) {
+                      bodyWritten= true;
+                      assert.isNotNull(body);
+                      assert.equal(body, "THIS_IS_A_POST_BODY_STRING")
+                    }
+                  }
+                }
+              };
+            }
+            oa._request("POST", "", {"Content-Type":"text/plain"}, "THIS_IS_A_POST_BODY_STRING");
+            assert.ok( bodyWritten );
+          },
+          'we should see a given buffer being sent to the request' : function(oa) {
+            var bodyWritten= false;
+            oa._oa._chooseHttpLibrary= function() {
+              return {
+                request: function(options) {
+                  assert.equal(options.headers["Content-Type"], "application/octet-stream");
+                  assert.equal(options.headers["Content-Length"], 4);
+                  assert.equal(options.method, "POST");
+                  return  {
+                    end: function() {},
+                    on: function() {},
+                    write: function(body) {
+                      bodyWritten= true;
+                      assert.isNotNull(body);
+                      assert.equal(4, body.length)
+                    }
+                  }
+                }
+              };
+            }
+            oa._request("POST", "", {"Content-Type":"application/octet-stream"}, new Buffer([1,2,3,4]));
+            assert.ok( bodyWritten );
+          }
+        },
+        'When PUTing': {
+          'we should see a given string being sent to the request' : function(oa) {
+            var bodyWritten= false;
+            oa._oa._chooseHttpLibrary= function() {
+              return {
+                request: function(options) {
+                  assert.equal(options.headers["Content-Type"], "text/plain");
+                  assert.equal(options.headers["Content-Length"], 25);
+                  assert.equal(options.method, "PUT");
+                  return  {
+                    end: function() {},
+                    on: function() {},
+                    write: function(body) {
+                      bodyWritten= true;
+                      assert.isNotNull(body);
+                      assert.equal(body, "THIS_IS_A_PUT_BODY_STRING")
+                    }
+                  }
+                }
+              };
+            }
+            oa._request("PUT", "", {"Content-Type":"text/plain"}, "THIS_IS_A_PUT_BODY_STRING");
+            assert.ok( bodyWritten );
+          },
+          'we should see a given buffer being sent to the request' : function(oa) {
+            var bodyWritten= false;
+            oa._oa._chooseHttpLibrary= function() {
+              return {
+                request: function(options) {
+                  assert.equal(options.headers["Content-Type"], "application/octet-stream");
+                  assert.equal(options.headers["Content-Length"], 4);
+                  assert.equal(options.method, "PUT");
+                  return  {
+                    end: function() {},
+                    on: function() {},
+                    write: function(body) {
+                      bodyWritten= true;
+                      assert.isNotNull(body);
+                      assert.equal(4, body.length)
+                    }
+                  }
+                }
+              };
+            }
+            oa._request("PUT", "", {"Content-Type":"application/octet-stream"}, new Buffer([1,2,3,4]));
+            assert.ok( bodyWritten );
+          }
+        }
+    },
+    'When the user passes in the User-Agent in customHeaders': {
+      topic: new OAuth2("clientId", "clientSecret", undefined, undefined, undefined,
+          { 'User-Agent': '123Agent' }),
+      'When calling get': {
+        'we should see the User-Agent mixed into headers property in options passed to http-library' : function(oa) {
+          oa._executeRequest= function( http_library, options, callback ) {
+            assert.equal(options.headers["User-Agent"], "123Agent");
+          };
+          oa.get("", {});
+        }
+      }
+    },
+    'When the user does not pass in a User-Agent in customHeaders': {
+      topic: new OAuth2("clientId", "clientSecret", undefined, undefined, undefined,
+        undefined),
+      'When calling get': {
+        'we should see the default User-Agent mixed into headers property in options passed to http-library' : function(oa) {
+          oa._executeRequest= function( http_library, options, callback ) {
+            assert.equal(options.headers["User-Agent"], "Node-oauth");
+            };
+          oa.get("", {});
+        }
+      }
+    }
+}).export(module);

--- a/tests/oauthpromise-tests.js
+++ b/tests/oauthpromise-tests.js
@@ -158,8 +158,8 @@ vows.describe('OAuth').addBatch({
   'When signing a url': {
     topic: function() {
       var oa= new OAuth(null, null, "consumerkey", "consumersecret", "1.0", null, "HMAC-SHA1");
-      oa._getTimestamp= function(){ return "1272399856"; };
-      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; };
+      oa._oa._getTimestamp= function(){ return "1272399856"; };
+      oa._oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; };
       return oa;
     },
     'Provide a valid signature when no token present': function(oa) {

--- a/tests/oauthpromise-tests.js
+++ b/tests/oauthpromise-tests.js
@@ -53,9 +53,9 @@ vows.describe('OAuth').addBatch({
     'we get a valid oauth signature': function (oa) {
       var signatureBase = "GET&http%3A%2F%2Fphotos.example.net%2Fphotos&file%3Dvacation.jpg%26oauth_consumer_key%3Ddpf43f3p2l4k3l03%26oauth_nonce%3Dkllo9940pd9333jh%26oauth_signature_method%3DRSA-SHA1%26oauth_timestamp%3D1191242096%26oauth_token%3Dnnch734d00sl2jdk%26oauth_version%3D1.0%26size%3Doriginal";
       var oauthSignature = oa._createSignature(signatureBase, "xyz4992k83j47x0b");
-      
+
       assert.equal( oauthSignature, "qS4rhWog7GPgo4ZCJvUdC/1ZAax/Q4Ab9yOBvgxSopvmKUKp5rso+Zda46GbyN2hnYDTiA/g3P/d/YiPWa454BEBb/KWFV83HpLDIoqUUhJnlXX9MqRQQac0oeope4fWbGlfTdL2PXjSFJmvfrzybERD/ZufsFtVrQKS3QBpYiw=");
-      
+
       //now check that given the public key we can verify this signature
       var verifier = crypto.createVerify("RSA-SHA1").update(signatureBase);
       var valid = verifier.verify(RsaPublicKey, oauthSignature, 'base64');
@@ -81,7 +81,7 @@ vows.describe('OAuth').addBatch({
       assert.equal( oa._normalizeUrl("http://somehost.com:81/foo/bar"), "http://somehost.com:81/foo/bar" );
     },
     'should add a trailing slash when no path at all is present': function(oa) {
-      assert.equal( oa._normalizeUrl("http://somehost.com"),  "http://somehost.com/")
+      assert.equal(oa._normalizeUrl("http://somehost.com"), "http://somehost.com/");
     }
   },
   'When making an array out of the arguments hash' : {
@@ -104,7 +104,7 @@ vows.describe('OAuth').addBatch({
       var parameters= {"z": "a",
                        "a": "b",
                        "1": "c" };
-      var parameterResults= oa._sortRequestParams(oa._makeArrayOfArgumentsHash(parameters))
+      var parameterResults= oa._sortRequestParams(oa._makeArrayOfArgumentsHash(parameters));
       assert.equal(parameterResults[0][0], "1");
       assert.equal(parameterResults[1][0], "a");
       assert.equal(parameterResults[2][0], "z");
@@ -113,7 +113,7 @@ vows.describe('OAuth').addBatch({
       var parameters= {"z": "a",
                        "a": ["z", "b", "b", "a", "y"],
                        "1": "c" };
-      var parameterResults= oa._sortRequestParams(oa._makeArrayOfArgumentsHash(parameters))
+      var parameterResults= oa._sortRequestParams(oa._makeArrayOfArgumentsHash(parameters));
       assert.equal(parameterResults[0][0], "1");
       assert.equal(parameterResults[1][0], "a");
       assert.equal(parameterResults[1][1], "a");
@@ -149,17 +149,17 @@ vows.describe('OAuth').addBatch({
     topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
     'We need to be wary of node\'s auto object creation from foo[bar] style url parameters' : function(oa) {
       var result= oa._prepareParameters( "", "", "", "http://foo.com?foo[bar]=xxx&bar[foo]=yyy", {} );
-      assert.equal( result[0][0], "bar[foo]")
-      assert.equal( result[0][1], "yyy")
-      assert.equal( result[1][0], "foo[bar]")
-      assert.equal( result[1][1], "xxx")
+      assert.equal( result[0][0], "bar[foo]");
+      assert.equal( result[0][1], "yyy");
+      assert.equal( result[1][0], "foo[bar]");
+      assert.equal( result[1][1], "xxx");
     }
   },
   'When signing a url': {
     topic: function() {
       var oa= new OAuth(null, null, "consumerkey", "consumersecret", "1.0", null, "HMAC-SHA1");
-      oa._getTimestamp= function(){ return "1272399856"; }
-      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; }
+      oa._getTimestamp= function(){ return "1272399856"; };
+      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; };
       return oa;
     },
     'Provide a valid signature when no token present': function(oa) {
@@ -175,9 +175,9 @@ vows.describe('OAuth').addBatch({
   'When getting a request token': {
     topic: function() {
       var oa= new OAuth(null, null, "consumerkey", "consumersecret", "1.0", null, "HMAC-SHA1");
-      oa._getTimestamp= function(){ return "1272399856"; }
-      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; }
-      oa._performSecureRequest= function(){ return this.requestArguments = arguments; }
+      oa._getTimestamp= function(){ return "1272399856"; };
+      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; };
+      oa._performSecureRequest= function(){ return this.requestArguments = arguments; };
       return oa;
     },
     'Use the HTTP method in the client options': function(oa) {
@@ -236,8 +236,8 @@ vows.describe('OAuth').addBatch({
       var realm = "http://foobar.com/";
       var verifyCredentials = "http://api.foobar.com/verify.json";
       var oa = new OAuthEcho(realm, verifyCredentials, "consumerkey", "consumersecret", "1.0A", "HMAC-SHA1");
-      oa._getTimestamp= function(){ return "1272399856"; }
-      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; }
+      oa._getTimestamp= function(){ return "1272399856"; };
+      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; };
       return oa;
     },
     'Provide a valid signature when a token and token secret is present': function (oa) {
@@ -257,11 +257,11 @@ vows.describe('OAuth').addBatch({
           on: function() {},
           end: function() {}
         };
-      }
+      };
       return oa;
     },
     'getProtectedResource should correctly define the host headers': function(oa) {
-      oa.getProtectedResource("http://somehost.com:8080", "GET", "oauth_token", null, function(){})
+      oa.getProtectedResource("http://somehost.com:8080", "GET", "oauth_token", null, function(){});
     }
   },
   'When building the OAuth Authorization header': {
@@ -320,7 +320,7 @@ vows.describe('OAuth').addBatch({
                 assert.equal(post_body,"scope=foobar%2C1%2C2");
               }
             };
-          }
+          };
           oa._performSecureRequest("token", "token_secret", 'POST', 'http://foo.com/protected_resource', {"scope": "foobar,1,2"});
           assert.equal(post_body_written, true);
         }
@@ -338,7 +338,7 @@ vows.describe('OAuth').addBatch({
     'POST' : {
       'if no callback is passed' : {
         'it should return a request object': function(oa) {
-          var request= oa.post("http://foo.com/blah", "token", "token_secret", "BLAH", "text/plain")
+          var request= oa.post("http://foo.com/blah", "token", "token_secret", "BLAH", "text/plain");
           assert.isObject(request);
           assert.equal(request.method, "POST");
           request.end();
@@ -357,8 +357,8 @@ vows.describe('OAuth').addBatch({
                   callbackCalled= true;
                 }
               };
-            }
-            var request= oa.post("http://foo.com/blah", "token", "token_secret", "BLAH", "text/plain", function(e,d){})
+            };
+            var request= oa.post("http://foo.com/blah", "token", "token_secret", "BLAH", "text/plain", function(e,d){});
             assert.equal(callbackCalled, true);
             assert.isUndefined(request);
           }
@@ -373,7 +373,7 @@ vows.describe('OAuth').addBatch({
           try {
             var callbackCalled= false;
             oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
-              assert.equal(headers["Content-Type"], "image/jpeg")
+              assert.equal(headers["Content-Type"], "image/jpeg");
               return {
                 write: function(data){
                   callbackCalled= true;
@@ -418,15 +418,15 @@ vows.describe('OAuth').addBatch({
         }
       },
       'if the post_body is not a string or a buffer' : {
-        "It should be url encoded and the content type set to be x-www-form-urlencoded" : function(oa) {
-          var op= oa._createClient;
+        "It should be url encoded and the content type set to be x-www-form-urlencoded": function(oa) {
+          var op = oa._createClient;
           try {
             var callbackCalled= false;
-            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+            oa._createClient= function(port, hostname, method, path, headers, sshEnabled) {
               assert.equal(headers["Content-Type"], "application/x-www-form-urlencoded");
               return {
-                write: function(data){
-                  callbackCalled= true;
+                write: function(data) {
+                  callbackCalled = true;
                   assert.equal(data, "foo=1%2C2%2C3&bar=1%2B2");
                 },
                 on: function() {},
@@ -434,10 +434,9 @@ vows.describe('OAuth').addBatch({
                 }
               };
             };
-            var request= oa.post("http://foo.com/blah", "token", "token_secret", {"foo":"1,2,3", "bar":"1+2"});
+            var request = oa.post("http://foo.com/blah", "token", "token_secret", { "foo": "1,2,3", "bar": "1+2" });
             assert.equal(callbackCalled, true);
-          }
-          finally {
+          } finally {
             oa._createClient= op;
           }
         }
@@ -839,64 +838,58 @@ vows.describe('OAuth').addBatch({
             var op= oa._createClient;
             var callbackCalled = false;
             try {
-              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
-                return new DummyRequest( new DummyResponse(301) );
+              oa._oa._createClient = function (port, hostname, method, path, headers, sshEnabled) {
+                return new DummyRequest(new DummyResponse(301));
               };
-              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(error) {
-                // callback
+              oa._oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', { "scope": "foobar,1,2" }, null, null, function(error) {
                 assert.equal(error.statusCode, 301);
-                callbackCalled= true;
+                callbackCalled = true;
               });
               assert.equal(callbackCalled, true);
-            }
-            finally {
-              oa._createClient= op;
+            } finally {
+              oa._oa._createClient = op;
             }
           }
         },
         'and followRedirect is true' : {
           'it should (re)perform the secure request but with the new location' : function(oa) {
-            var op= oa._createClient;
-            var psr= oa._performSecureRequest;
+            var op = oa._oa._createClient;
+            var psr = oa._oa._performSecureRequest;
             var responseCounter = 1;
             var callbackCalled = false;
-            var DummyResponse =function() {
-              if( responseCounter == 1 ){
-                this.statusCode= 301;
-                this.headers= {location:"http://redirectto.com"};
+            var DummyResponse = function() {
+              if (responseCounter === 1) {
+                this.statusCode = 301;
+                this.headers = { location: "http://redirectto.com" };
                 responseCounter++;
-              }
-              else {
-                this.statusCode= 200;
+              } else {
+                this.statusCode = 200;
               }
             };
-            DummyResponse.prototype= events.EventEmitter.prototype;
+            DummyResponse.prototype = events.EventEmitter.prototype;
             DummyResponse.prototype.setEncoding = function() {};
 
             try {
-              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
-                return new DummyRequest( new DummyResponse() );
+              oa._oa._createClient = function(port, hostname, method, path, headers, sshEnabled) {
+                return new DummyRequest(new DummyResponse());
               };
-              oa._performSecureRequest= function( oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback ) {
-                if( responseCounter == 1 ) {
+              oa._oa._performSecureRequest = function(oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback) {
+                if (responseCounter === 1) {
                   assert.equal(url, "http://originalurl.com");
-                }
-                else {
+                } else {
                   assert.equal(url, "http://redirectto.com");
                 }
-                return psr.call(oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback );
+                return psr.call(oa._oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type, callback);
               };
 
-              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function() {
-                // callback
+              oa._oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', { "scope": "foobar,1,2" }, null, null, function() {
                 assert.equal(responseCounter, 2);
-                callbackCalled= true;
+                callbackCalled = true;
               });
-              assert.equal(callbackCalled, true)
-            }
-            finally {
-              oa._createClient= op;
-              oa._performSecureRequest= psr;
+              assert.equal(callbackCalled, true);
+            } finally {
+              oa._oa._createClient = op;
+              oa._oa._performSecureRequest = psr;
             }
           }
         },
@@ -907,142 +900,6 @@ vows.describe('OAuth').addBatch({
             var DummyResponse =function() {
               this.statusCode= 301;
               this.headers= {location:"http://redirectto.com"};
-            }
-            DummyResponse.prototype= events.EventEmitter.prototype;
-            DummyResponse.prototype.setEncoding= function() {}
-
-            try {
-              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
-                return new DummyRequest( new DummyResponse() );
-              }
-              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(res, data, response) {
-                // callback
-                assert.equal(res.statusCode, 301);
-              });
-            }
-            finally {
-              oa._createClient= op;
-              oa.setClientOptions({followRedirects:true});
-            }
-          }
-        }
-      },
-      'And A 302 redirect is received' : {
-        'and there is a location header' : {
-          'it should (re)perform the secure request but with the new location' : function(oa) {
-            var op= oa._createClient;
-            var psr= oa._performSecureRequest;
-            var responseCounter = 1;
-            var callbackCalled = false;
-            var DummyResponse =function() {
-              if( responseCounter == 1 ){
-                this.statusCode= 302;
-                this.headers= {location:"http://redirectto.com"};
-                responseCounter++;
-              } else {
-                this.statusCode= 200;
-              }
-            };
-            DummyResponse.prototype= events.EventEmitter.prototype;
-            DummyResponse.prototype.setEncoding = function() {};
-
-            try {
-              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
-                return new DummyRequest( new DummyResponse() );
-              }
-              oa._performSecureRequest= function( oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback ) {
-                if( responseCounter == 1 ) {
-                  assert.equal(url, "http://originalurl.com");
-                } else {
-                  assert.equal(url, "http://redirectto.com");
-                }
-                return psr.call(oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback )
-              }
-
-              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function() {
-                // callback
-                assert.equal(responseCounter, 2);
-                callbackCalled = true;
-              });
-              assert.equal(callbackCalled, true);
-            }
-            finally {
-              oa._createClient= op;
-              oa._performSecureRequest= psr;
-            }
-          }
-        },
-        'but there is no location header' : {
-          'it should execute the callback, passing the HTTP Response code' : function(oa) {
-            var op= oa._createClient;
-            var callbackCalled = false;
-            try {
-              oa._createClient = function(port, hostname, method, path, headers, sshEnabled ) {
-                return new DummyRequest(new DummyResponse(302));
-              };
-              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(error) {
-                // callback
-                assert.equal(error.statusCode, 302);
-                callbackCalled = true;
-              });
-              assert.equal(callbackCalled, true);
-            }
-            finally {
-              oa._createClient= op;
-            }
-          }
-        },
-        'and followRedirect is true' : {
-          'it should (re)perform the secure request but with the new location' : function(oa) {
-            var op= oa._createClient;
-            var psr= oa._performSecureRequest;
-            var responseCounter = 1;
-            var callbackCalled = false;
-            var DummyResponse = function() {
-              if (responseCounter == 1) {
-                this.statusCode= 302;
-                this.headers= {location:"http://redirectto.com"};
-                responseCounter++;
-              } else {
-                this.statusCode= 200;
-              }
-            };
-            DummyResponse.prototype= events.EventEmitter.prototype;
-            DummyResponse.prototype.setEncoding = function() {};
-
-            try {
-              oa._createClient = function(port, hostname, method, path, headers, sshEnabled) {
-                return new DummyRequest(new DummyResponse());
-              };
-              oa._performSecureRequest = function(oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback) {
-                if (responseCounter == 1) {
-                  assert.equal(url, "http://originalurl.com");
-                } else {
-                  assert.equal(url, "http://redirectto.com");
-                }
-                return psr.call(oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type, callback);
-              };
-
-              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function() {
-                // callback
-                assert.equal(responseCounter, 2);
-                callbackCalled = true;
-              });
-              assert.equal(callbackCalled, true);
-            }
-            finally {
-              oa._createClient= op;
-              oa._performSecureRequest= psr;
-            }
-          }
-        },
-        'and followRedirect is false' : {
-          'it should not perform the secure request with the new location' : function(oa) {
-            var op= oa._createClient;
-            oa.setClientOptions({ followRedirects: false });
-            var DummyResponse =function() {
-              this.statusCode= 302;
-              this.headers= {location:"http://redirectto.com"};
             };
             DummyResponse.prototype= events.EventEmitter.prototype;
             DummyResponse.prototype.setEncoding= function() {};
@@ -1051,14 +908,156 @@ vows.describe('OAuth').addBatch({
               oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
                 return new DummyRequest( new DummyResponse() );
               };
-              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(res, data, response) {
+              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', { "scope": "foobar,1,2" }, null, null, function(res, data, response) {
+                assert.equal(res.statusCode, 301);
+              });
+            } finally {
+              oa._createClient = op;
+              oa.setClientOptions({ followRedirects: true });
+            }
+          }
+        }
+      },
+      'And A 302 redirect is received' : {
+        'and there is a location header' : {
+          'it should (re)perform the secure request but with the new location' : function(oa) {
+            var op = oa._oa._createClient;
+            var psr = oa._oa._performSecureRequest;
+            var responseCounter = 1;
+            var callbackCalled = false;
+            var DummyResponse = function() {
+              if( responseCounter === 1 ){
+                this.statusCode = 302;
+                this.headers = { location: "http://redirectto.com" };
+                responseCounter++;
+              } else {
+                this.statusCode = 200;
+              }
+            };
+            DummyResponse.prototype = events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding = function() {};
+
+            try {
+              oa._oa._createClient= function(port, hostname, method, path, headers, sshEnabled) {
+                return new DummyRequest(new DummyResponse());
+              };
+              oa._oa._performSecureRequest = function(oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback) {
+                if (responseCounter === 1) {
+                  assert.equal(url, "http://originalurl.com");
+                } else {
+                  assert.equal(url, "http://redirectto.com");
+                }
+                return psr.call(oa._oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback);
+              };
+
+              oa._oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', { "scope": "foobar,1,2" }, null, null, function() {
+                // callback
+                assert.equal(responseCounter, 2);
+                callbackCalled = true;
+              });
+              assert.equal(callbackCalled, true);
+            } finally {
+              oa._oa._createClient = op;
+              oa._oa._performSecureRequest = psr;
+            }
+          }
+        },
+        'but there is no location header': {
+          'it should execute the callback, passing the HTTP Response code': function(oa) {
+            var op = oa._oa._createClient;
+            var callbackCalled = false;
+            try {
+
+              oa._oa._createClient = function(port, hostname, method, path, headers, sshEnabled ) {
+                return new DummyRequest(new DummyResponse(302));
+              };
+              oa._oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', { "scope": "foobar,1,2" }, null, null, function(error) {
+                assert.equal(error.statusCode, 302);
+                callbackCalled = true;
+              });
+              assert.equal(callbackCalled, true);
+
+            } finally {
+              oa._oa._createClient = op;
+            }
+          }
+        },
+        'and followRedirect is true': {
+          'it should (re)perform the secure request but with the new location': function(oa) {
+            var op = oa._oa._createClient;
+            var psr = oa._oa._performSecureRequest;
+            var responseCounter = 1;
+            var callbackCalled = false;
+            var DummyResponse = function() {
+
+              if (responseCounter === 1) {
+                this.statusCode = 302;
+                this.headers = {
+                  location: 'http://redirectto.com'
+                };
+                responseCounter++;
+              } else {
+                this.statusCode = 200;
+              }
+
+            };
+            DummyResponse.prototype = events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding = function() {};
+
+            try {
+
+              oa._oa._createClient = function(port, hostname, method, path, headers, sshEnabled) {
+                return new DummyRequest(new DummyResponse());
+              };
+              oa._oa._performSecureRequest = function(oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback) {
+
+                if (responseCounter === 1) {
+                  assert.equal(url, 'http://originalurl.com');
+                } else {
+                  assert.equal(url, 'http://redirectto.com');
+                }
+
+                return psr.call(oa._oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type, callback);
+              };
+              oa._oa._performSecureRequest('token', 'token_secret', 'POST', 'http://originalurl.com', { 'scope': 'foobar,1,2' }, null, null, function() {
+                // callback
+                assert.equal(responseCounter, 2);
+                callbackCalled = true;
+              });
+              assert.equal(callbackCalled, true);
+
+            } finally {
+
+              oa._oa._createClient = op;
+              oa._oa._performSecureRequest = psr;
+
+            }
+          }
+        },
+        'and followRedirect is false': {
+          'it should not perform the secure request with the new location': function(oa) {
+            var op = oa._oa._createClient;
+            oa.setClientOptions({ followRedirects: false });
+            var DummyResponse = function() {
+              this.statusCode = 302;
+              this.headers = {
+                location: 'http://redirectto.com'
+              };
+            };
+            DummyResponse.prototype = events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding = function() {};
+
+            try {
+              oa._oa._createClient= function(port, hostname, method, path, headers, sshEnabled) {
+                return new DummyRequest(new DummyResponse());
+              };
+              oa._oa._performSecureRequest('token', 'token_secret', 'POST', 'http://originalurl.com', { 'scope': 'foobar,1,2' }, null, null, function(res, data, response) {
                 // callback
                 assert.equal(res.statusCode, 302);
               });
-            }
-            finally {
-              oa._createClient= op;
-              oa.setClientOptions({followRedirects:true});
+            } finally {
+              oa._createClient = op;
+              oa.setClientOptions({ followRedirects: true });
             }
           }
         }

--- a/tests/oauthpromise-tests.js
+++ b/tests/oauthpromise-tests.js
@@ -1,0 +1,1068 @@
+var vows = require('vows'),
+    assert = require('assert'),
+    DummyResponse= require('./shared').DummyResponse,
+    DummyRequest= require('./shared').DummyRequest,
+    events = require('events'),
+    OAuth= require('../lib/oauth-promise').OAuth,
+    OAuthEcho= require('../lib/oauth').OAuthEcho,
+    crypto = require('crypto');
+
+//Valid RSA keypair used to test RSA-SHA1 signature method
+var RsaPrivateKey = "-----BEGIN RSA PRIVATE KEY-----\n" +
+      "MIICXQIBAAKBgQDizE4gQP5nPQhzof/Vp2U2DDY3UY/Gxha2CwKW0URe7McxtnmE\n" +
+      "CrZnT1n/YtfrrCNxY5KMP4o8hMrxsYEe05+1ZGFT68ztms3puUxilU5E3BQMhz1t\n" +
+      "JMJEGcTt8nZUlM4utli7fHgDtWbhvqvYjRMGn3AjyLOfY8XZvnFkGjipvQIDAQAB\n" +
+      "AoGAKgk6FcpWHOZ4EY6eL4iGPt1Gkzw/zNTcUsN5qGCDLqDuTq2Gmk2t/zn68VXt\n" +
+      "tVXDf/m3qN0CDzOBtghzaTZKLGhnSewQ98obMWgPcvAsb4adEEeW1/xigbMiaW2X\n" +
+      "cu6GhZxY16edbuQ40LRrPoVK94nXQpj8p7w4IQ301Sm8PSECQQD1ZlOj4ugvfhEt\n" +
+      "exi4WyAaM45fylmN290UXYqZ8SYPI/VliDytIlMfyq5Rv+l+dud1XDPrWOQ0ImgV\n" +
+      "HJn7uvoZAkEA7JhHNmHF9dbdF9Koj86K2Cl6c8KUu7U7d2BAuB6pPkt8+D8+y4St\n" +
+      "PaCmN4oP4X+sf5rqBYoXywHlqEei2BdpRQJBAMYgR4cZu7wcXGIL8HlnmROObHSK\n" +
+      "OqN9z5CRtUV0nPW8YnQG+nYOMG6KhRMbjri750OpnYF100kEPmRNI0VKQIECQE8R\n" +
+      "fQsRleTYz768ahTVQ9WF1ySErMwmfx8gDcD6jjkBZVxZVpURXAwyehopi7Eix/VF\n" +
+      "QlxjkBwKIEQi3Ks297kCQQCL9by1bueKDMJO2YX1Brm767pkDKkWtGfPS+d3xMtC\n" +
+      "KJHHCqrS1V+D5Q89x5wIRHKxE5UMTc0JNa554OxwFORX\n" +
+      "-----END RSA PRIVATE KEY-----";
+
+var RsaPublicKey = "-----BEGIN PUBLIC KEY-----\n" +
+      "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDizE4gQP5nPQhzof/Vp2U2DDY3\n" +
+      "UY/Gxha2CwKW0URe7McxtnmECrZnT1n/YtfrrCNxY5KMP4o8hMrxsYEe05+1ZGFT\n" +
+      "68ztms3puUxilU5E3BQMhz1tJMJEGcTt8nZUlM4utli7fHgDtWbhvqvYjRMGn3Aj\n" +
+      "yLOfY8XZvnFkGjipvQIDAQAB\n" +
+      "-----END PUBLIC KEY-----";
+
+vows.describe('OAuth').addBatch({
+  'When newing OAuth': {
+    topic: new OAuth(null, null, null, null, null, null, "PLAINTEXT"),
+    'followRedirects is enabled by default': function (oa) {
+      assert.equal(oa._oa._clientOptions.followRedirects, true);
+    }
+  },
+  'When generating the signature base string described in http://oauth.net/core/1.0/#sig_base_example': {
+    topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
+    'we get the expected result string': function (oa) {
+      var result= oa._createSignatureBase(
+        "GET", "http://photos.example.net/photos",
+        "file=vacation.jpg&oauth_consumer_key=dpf43f3p2l4k3l03&oauth_nonce=kllo9940pd9333jh&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1191242096&oauth_token=nnch734d00sl2jdk&oauth_version=1.0&size=original"
+      );
+      assert.equal(result, "GET&http%3A%2F%2Fphotos.example.net%2Fphotos&file%3Dvacation.jpg%26oauth_consumer_key%3Ddpf43f3p2l4k3l03%26oauth_nonce%3Dkllo9940pd9333jh%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1191242096%26oauth_token%3Dnnch734d00sl2jdk%26oauth_version%3D1.0%26size%3Doriginal");
+    }
+  },
+  'When generating the signature with RSA-SHA1': {
+    topic: new OAuth(null, null, null, RsaPrivateKey, null, null, "RSA-SHA1"),
+    'we get a valid oauth signature': function (oa) {
+      var signatureBase = "GET&http%3A%2F%2Fphotos.example.net%2Fphotos&file%3Dvacation.jpg%26oauth_consumer_key%3Ddpf43f3p2l4k3l03%26oauth_nonce%3Dkllo9940pd9333jh%26oauth_signature_method%3DRSA-SHA1%26oauth_timestamp%3D1191242096%26oauth_token%3Dnnch734d00sl2jdk%26oauth_version%3D1.0%26size%3Doriginal";
+      var oauthSignature = oa._createSignature(signatureBase, "xyz4992k83j47x0b");
+      
+      assert.equal( oauthSignature, "qS4rhWog7GPgo4ZCJvUdC/1ZAax/Q4Ab9yOBvgxSopvmKUKp5rso+Zda46GbyN2hnYDTiA/g3P/d/YiPWa454BEBb/KWFV83HpLDIoqUUhJnlXX9MqRQQac0oeope4fWbGlfTdL2PXjSFJmvfrzybERD/ZufsFtVrQKS3QBpYiw=");
+      
+      //now check that given the public key we can verify this signature
+      var verifier = crypto.createVerify("RSA-SHA1").update(signatureBase);
+      var valid = verifier.verify(RsaPublicKey, oauthSignature, 'base64');
+      assert.ok( valid, "Signature could not be verified with RSA public key");
+    }
+  },
+  'When generating the signature base string with PLAINTEXT': {
+    topic: new OAuth(null, null, null, null, null, null, "PLAINTEXT"),
+    'we get the expected result string': function (oa) {
+      var result= oa._getSignature("GET", "http://photos.example.net/photos",
+                                   "file=vacation.jpg&oauth_consumer_key=dpf43f3p2l4k3l03&oauth_nonce=kllo9940pd9333jh&oauth_signature_method=PLAINTEXT&oauth_timestamp=1191242096&oauth_token=nnch734d00sl2jdk&oauth_version=1.0&size=original",
+                                   "test");
+      assert.equal( result, "&test");
+    }
+  },
+  'When normalising a url': {
+    topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
+    'default ports should be stripped': function(oa) {
+      assert.equal( oa._normalizeUrl("https://somehost.com:443/foo/bar"), "https://somehost.com/foo/bar" );
+    },
+    'should leave in non-default ports from urls for use in signature generation': function(oa) {
+      assert.equal( oa._normalizeUrl("https://somehost.com:446/foo/bar"), "https://somehost.com:446/foo/bar" );
+      assert.equal( oa._normalizeUrl("http://somehost.com:81/foo/bar"), "http://somehost.com:81/foo/bar" );
+    },
+    'should add a trailing slash when no path at all is present': function(oa) {
+      assert.equal( oa._normalizeUrl("http://somehost.com"),  "http://somehost.com/")
+    }
+  },
+  'When making an array out of the arguments hash' : {
+    topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
+    'flatten out arguments that are arrays' : function(oa) {
+      var parameters= {"z": "a",
+                       "a": ["1", "2"],
+                       "1": "c" };
+      var parameterResults= oa._makeArrayOfArgumentsHash(parameters);
+      assert.equal(parameterResults.length, 4);
+      assert.equal(parameterResults[0][0], "1");
+      assert.equal(parameterResults[1][0], "z");
+      assert.equal(parameterResults[2][0], "a");
+      assert.equal(parameterResults[3][0], "a");
+    }
+  },
+  'When ordering the request parameters'  : {
+    topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
+    'Order them by name' : function(oa) {
+      var parameters= {"z": "a",
+                       "a": "b",
+                       "1": "c" };
+      var parameterResults= oa._sortRequestParams(oa._makeArrayOfArgumentsHash(parameters))
+      assert.equal(parameterResults[0][0], "1");
+      assert.equal(parameterResults[1][0], "a");
+      assert.equal(parameterResults[2][0], "z");
+    },
+    'If two parameter names are the same then order by the value': function(oa) {
+      var parameters= {"z": "a",
+                       "a": ["z", "b", "b", "a", "y"],
+                       "1": "c" };
+      var parameterResults= oa._sortRequestParams(oa._makeArrayOfArgumentsHash(parameters))
+      assert.equal(parameterResults[0][0], "1");
+      assert.equal(parameterResults[1][0], "a");
+      assert.equal(parameterResults[1][1], "a");
+      assert.equal(parameterResults[2][0], "a");
+      assert.equal(parameterResults[2][1], "b");
+      assert.equal(parameterResults[3][0], "a");
+      assert.equal(parameterResults[3][1], "b");
+      assert.equal(parameterResults[4][0], "a");
+      assert.equal(parameterResults[4][1], "y");
+      assert.equal(parameterResults[5][0], "a");
+      assert.equal(parameterResults[5][1], "z");
+      assert.equal(parameterResults[6][0], "z");
+    }
+  },
+  'When normalising the request parameters': {
+    topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
+    'the resulting parameters should be encoded and ordered as per http://tools.ietf.org/html/rfc5849#section-3.1 (3.4.1.3.2)' : function(oa) {
+      var parameters= {"b5" : "=%3D",
+                       "a3": ["a", "2 q"],
+                       "c@": "",
+                       "a2": "r b",
+                       "oauth_consumer_key": "9djdj82h48djs9d2",
+                       "oauth_token":"kkk9d7dh3k39sjv7",
+                       "oauth_signature_method": "HMAC-SHA1",
+                       "oauth_timestamp": "137131201",
+                       "oauth_nonce": "7d8f3e4a",
+                       "c2" :  ""};
+      var normalisedParameterString= oa._normaliseRequestParams(parameters);
+      assert.equal(normalisedParameterString, "a2=r%20b&a3=2%20q&a3=a&b5=%3D%253D&c%40=&c2=&oauth_consumer_key=9djdj82h48djs9d2&oauth_nonce=7d8f3e4a&oauth_signature_method=HMAC-SHA1&oauth_timestamp=137131201&oauth_token=kkk9d7dh3k39sjv7");
+    }
+  },
+  'When preparing the parameters for use in signing': {
+    topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
+    'We need to be wary of node\'s auto object creation from foo[bar] style url parameters' : function(oa) {
+      var result= oa._prepareParameters( "", "", "", "http://foo.com?foo[bar]=xxx&bar[foo]=yyy", {} );
+      assert.equal( result[0][0], "bar[foo]")
+      assert.equal( result[0][1], "yyy")
+      assert.equal( result[1][0], "foo[bar]")
+      assert.equal( result[1][1], "xxx")
+    }
+  },
+  'When signing a url': {
+    topic: function() {
+      var oa= new OAuth(null, null, "consumerkey", "consumersecret", "1.0", null, "HMAC-SHA1");
+      oa._getTimestamp= function(){ return "1272399856"; }
+      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; }
+      return oa;
+    },
+    'Provide a valid signature when no token present': function(oa) {
+      assert.equal( oa.signUrl("http://somehost.com:3323/foo/poop?bar=foo"), "http://somehost.com:3323/foo/poop?bar=foo&oauth_consumer_key=consumerkey&oauth_nonce=ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1272399856&oauth_version=1.0&oauth_signature=7ytO8vPSLut2GzHjU9pn1SV9xjc%3D");
+    },
+    'Provide a valid signature when a token is present': function(oa) {
+      assert.equal( oa.signUrl("http://somehost.com:3323/foo/poop?bar=foo", "token"), "http://somehost.com:3323/foo/poop?bar=foo&oauth_consumer_key=consumerkey&oauth_nonce=ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1272399856&oauth_token=token&oauth_version=1.0&oauth_signature=9LwCuCWw5sURtpMroIolU3YwsdI%3D");
+    },
+    'Provide a valid signature when a token and a token secret is present': function(oa) {
+      assert.equal( oa.signUrl("http://somehost.com:3323/foo/poop?bar=foo", "token", "tokensecret"), "http://somehost.com:3323/foo/poop?bar=foo&oauth_consumer_key=consumerkey&oauth_nonce=ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1272399856&oauth_token=token&oauth_version=1.0&oauth_signature=zeOR0Wsm6EG6XSg0Vw%2FsbpoSib8%3D");
+    }
+  },
+  'When getting a request token': {
+    topic: function() {
+      var oa= new OAuth(null, null, "consumerkey", "consumersecret", "1.0", null, "HMAC-SHA1");
+      oa._getTimestamp= function(){ return "1272399856"; }
+      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; }
+      oa._performSecureRequest= function(){ return this.requestArguments = arguments; }
+      return oa;
+    },
+    'Use the HTTP method in the client options': function(oa) {
+      oa.setClientOptions({ requestTokenHttpMethod: "GET" });
+      oa.getOAuthRequestToken(function() {}).nodeify(function() {
+        assert.equal(oa.requestArguments[2], "GET");
+      });
+    },
+    'Use a POST by default': function(oa) {
+      oa.setClientOptions({});
+      oa.getOAuthRequestToken(function() {}).nodeify(function() {
+        assert.equal(oa.requestArguments[2], "POST");
+      });
+    }
+  },
+  'When getting an access token': {
+    topic: function() {
+      var oa = new OAuth(null, null, "consumerkey", "consumersecret", "1.0", null, "HMAC-SHA1");
+      oa._getTimestamp = function() { return "1272399856"; };
+      oa._getNonce = function() { return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; };
+      oa._performSecureRequest= function() {
+        return this._oa.requestArguments = arguments;
+      };
+      return oa;
+    },
+    'Use the HTTP method in the client options': function(oa) {
+      oa.setClientOptions({ accessTokenHttpMethod: "GET" });
+      oa.getOAuthAccessToken(function() {}).nodeify(function() {
+        assert.equal(oa._oa.requestArguments[2], "GET");
+      });
+    },
+    'Use a POST by default': function(oa) {
+      oa.setClientOptions({});
+      oa.getOAuthAccessToken(function() {}).nodeify(function() {
+        assert.equal(oa._oa.requestArguments[2], "POST");
+      });
+    }
+  },
+  'When get authorization header' : {
+    topic: function() {
+      var oa= new OAuth(null, null, "consumerkey", "consumersecret", "1.0", null, "HMAC-SHA1");
+      oa._getTimestamp = function() { return "1272399856"; };
+      oa._getNonce = function() { return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; };
+      return oa;
+    },
+    'Provide a valid signature when a token and a token secret is present': function(oa) {
+      assert.equal( oa.authHeader("http://somehost.com:3323/foo/poop?bar=foo", "token", "tokensecret"), 'OAuth oauth_consumer_key="consumerkey",oauth_nonce="ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp",oauth_signature_method="HMAC-SHA1",oauth_timestamp="1272399856",oauth_token="token",oauth_version="1.0",oauth_signature="zeOR0Wsm6EG6XSg0Vw%2FsbpoSib8%3D"');
+    },
+    'Support variable whitespace separating the arguments': function(oa) {
+      oa._oauthParameterSeperator= ", ";
+      assert.equal( oa.authHeader("http://somehost.com:3323/foo/poop?bar=foo", "token", "tokensecret"), 'OAuth oauth_consumer_key="consumerkey", oauth_nonce="ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1272399856", oauth_token="token", oauth_version="1.0", oauth_signature="zeOR0Wsm6EG6XSg0Vw%2FsbpoSib8%3D"');
+    }
+  },
+  'When get the OAuth Echo authorization header': {
+    topic: function () {
+      var realm = "http://foobar.com/";
+      var verifyCredentials = "http://api.foobar.com/verify.json";
+      var oa = new OAuthEcho(realm, verifyCredentials, "consumerkey", "consumersecret", "1.0A", "HMAC-SHA1");
+      oa._getTimestamp= function(){ return "1272399856"; }
+      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; }
+      return oa;
+    },
+    'Provide a valid signature when a token and token secret is present': function (oa) {
+      assert.equal( oa.authHeader("http://somehost.com:3323/foo/poop?bar=foo", "token", "tokensecret"), 'OAuth realm="http://foobar.com/",oauth_consumer_key="consumerkey",oauth_nonce="ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp",oauth_signature_method="HMAC-SHA1",oauth_timestamp="1272399856",oauth_token="token",oauth_version="1.0A",oauth_signature="0rr1LhSxACX2IEWRq3uCb4IwtOs%3D"');
+    }
+  },
+  'When non standard ports are used': {
+    topic: function() {
+      var oa= new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
+          mockProvider= {};
+
+      oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+        assert.equal(headers.Host, "somehost.com:8080");
+        assert.equal(hostname, "somehost.com");
+        assert.equal(port, "8080");
+        return {
+          on: function() {},
+          end: function() {}
+        };
+      }
+      return oa;
+    },
+    'getProtectedResource should correctly define the host headers': function(oa) {
+      oa.getProtectedResource("http://somehost.com:8080", "GET", "oauth_token", null, function(){})
+    }
+  },
+  'When building the OAuth Authorization header': {
+    topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
+    'All provided oauth arguments should be concatentated correctly' : function(oa) {
+      var parameters= [
+        ["oauth_timestamp",         "1234567"],
+        ["oauth_nonce",             "ABCDEF"],
+        ["oauth_version",           "1.0"],
+        ["oauth_signature_method",  "HMAC-SHA1"],
+        ["oauth_consumer_key",      "asdasdnm2321b3"]];
+      assert.equal(oa._buildAuthorizationHeaders(parameters), 'OAuth oauth_timestamp="1234567",oauth_nonce="ABCDEF",oauth_version="1.0",oauth_signature_method="HMAC-SHA1",oauth_consumer_key="asdasdnm2321b3"');
+    },
+    '*Only* Oauth arguments should be concatentated, others should be disregarded' : function(oa) {
+      var parameters= [
+        ["foo",         "2343"],
+        ["oauth_timestamp",         "1234567"],
+        ["oauth_nonce",             "ABCDEF"],
+        ["bar",             "dfsdfd"],
+        ["oauth_version",           "1.0"],
+        ["oauth_signature_method",  "HMAC-SHA1"],
+        ["oauth_consumer_key",      "asdasdnm2321b3"],
+        ["foobar",      "asdasdnm2321b3"]];
+      assert.equal(oa._buildAuthorizationHeaders(parameters), 'OAuth oauth_timestamp="1234567",oauth_nonce="ABCDEF",oauth_version="1.0",oauth_signature_method="HMAC-SHA1",oauth_consumer_key="asdasdnm2321b3"');
+    },
+    '_buildAuthorizationHeaders should not depends on Array.prototype.toString' : function(oa) {
+      var _toString = Array.prototype.toString;
+      Array.prototype.toString = function(){ return '[Array] ' + this.length; }; // toString overwrite example used in jsdom.
+      var parameters= [
+        ["foo",         "2343"],
+        ["oauth_timestamp",         "1234567"],
+        ["oauth_nonce",             "ABCDEF"],
+        ["bar",             "dfsdfd"],
+        ["oauth_version",           "1.0"],
+        ["oauth_signature_method",  "HMAC-SHA1"],
+        ["oauth_consumer_key",      "asdasdnm2321b3"],
+        ["foobar",      "asdasdnm2321b3"]];
+      assert.equal(oa._buildAuthorizationHeaders(parameters), 'OAuth oauth_timestamp="1234567",oauth_nonce="ABCDEF",oauth_version="1.0",oauth_signature_method="HMAC-SHA1",oauth_consumer_key="asdasdnm2321b3"');
+      Array.prototype.toString = _toString;
+    }
+  },
+  'When performing the Secure Request' : {
+    topic: new OAuth("http://foo.com/RequestToken",
+                     "http://foo.com/AccessToken",
+                     "anonymous",  "anonymous",
+                     "1.0A", "http://foo.com/callback", "HMAC-SHA1"),
+    'using the POST method' : {
+      'Any passed extra_params should form part of the POST body': function(oa) {
+        var post_body_written= false;
+        var op= oa._createClient;
+        try {
+          oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+            return {
+              write: function(post_body){
+                post_body_written= true;
+                assert.equal(post_body,"scope=foobar%2C1%2C2");
+              }
+            };
+          }
+          oa._performSecureRequest("token", "token_secret", 'POST', 'http://foo.com/protected_resource', {"scope": "foobar,1,2"});
+          assert.equal(post_body_written, true);
+        }
+        finally {
+          oa._createClient= op;
+        }
+      }
+    }
+  },
+  'When performing a secure' : {
+    topic: new OAuth("http://foo.com/RequestToken",
+                     "http://foo.com/AccessToken",
+                     "anonymous",  "anonymous",
+                     "1.0A", "http://foo.com/callback", "HMAC-SHA1"),
+    'POST' : {
+      'if no callback is passed' : {
+        'it should return a request object': function(oa) {
+          var request= oa.post("http://foo.com/blah", "token", "token_secret", "BLAH", "text/plain")
+          assert.isObject(request);
+          assert.equal(request.method, "POST");
+          request.end();
+        }
+      },
+      'if a callback is passed' : {
+        "it should call the internal request's end method and return nothing": function(oa) {
+          var callbackCalled= false;
+          var op= oa._createClient;
+          try {
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              return {
+                write: function(){},
+                on: function() {},
+                end: function() {
+                  callbackCalled= true;
+                }
+              };
+            }
+            var request= oa.post("http://foo.com/blah", "token", "token_secret", "BLAH", "text/plain", function(e,d){})
+            assert.equal(callbackCalled, true);
+            assert.isUndefined(request);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      },
+      'if the post_body is a buffer' : {
+        "It should be passed through as is, and the original content-type (if specified) should be passed through": function(oa) {
+          var op= oa._createClient;
+          try {
+            var callbackCalled= false;
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              assert.equal(headers["Content-Type"], "image/jpeg")
+              return {
+                write: function(data){
+                  callbackCalled= true;
+                  assert.equal(data.length, 4);
+                },
+                on: function() {},
+                end: function() {
+                }
+              };
+            };
+            var request= oa.post("http://foo.com/blah", "token", "token_secret", new Buffer([10,20,30,40]), "image/jpeg");
+            assert.equal(callbackCalled, true);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        },
+        "It should be passed through as is, and no content-type is specified.": function(oa) {
+          //Should probably actually set application/octet-stream, but to avoid a change in behaviour
+          // will just document (here) that the library will set it to application/x-www-form-urlencoded
+          var op= oa._createClient;
+          try {
+            var callbackCalled= false;
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              assert.equal(headers["Content-Type"], "application/x-www-form-urlencoded");
+              return {
+                write: function(data){
+                  callbackCalled= true;
+                  assert.equal(data.length, 4);
+                },
+                on: function() {},
+                end: function() {
+                }
+              };
+            };
+            var request= oa.post("http://foo.com/blah", "token", "token_secret", new Buffer([10,20,30,40]));
+            assert.equal(callbackCalled, true);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      },
+      'if the post_body is not a string or a buffer' : {
+        "It should be url encoded and the content type set to be x-www-form-urlencoded" : function(oa) {
+          var op= oa._createClient;
+          try {
+            var callbackCalled= false;
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              assert.equal(headers["Content-Type"], "application/x-www-form-urlencoded");
+              return {
+                write: function(data){
+                  callbackCalled= true;
+                  assert.equal(data, "foo=1%2C2%2C3&bar=1%2B2");
+                },
+                on: function() {},
+                end: function() {
+                }
+              };
+            };
+            var request= oa.post("http://foo.com/blah", "token", "token_secret", {"foo":"1,2,3", "bar":"1+2"});
+            assert.equal(callbackCalled, true);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      },
+      'if the post_body is a string' : {
+        "and it contains non ascii (7/8bit) characters" : {
+          "the content length should be the byte count, and not the string length"  : function(oa) {
+            var testString= "Tôi yêu node";
+            var testStringLength= testString.length;
+            var testStringBytesLength= Buffer.byteLength(testString);
+            assert.notEqual(testStringLength, testStringBytesLength); // Make sure we're testing a string that differs between byte-length and char-length!
+
+            var op= oa._createClient;
+            try {
+              var callbackCalled= false;
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                assert.equal(headers["Content-length"], testStringBytesLength);
+                return {
+                  write: function(data){
+                    callbackCalled= true;
+                    assert.equal(data, testString);
+                  },
+                  on: function() {},
+                  end: function() {
+                  }
+                };
+              };
+              var request= oa.post("http://foo.com/blah", "token", "token_secret", "Tôi yêu node");
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+            }
+          }
+        },
+        "and no post_content_type is specified" : {
+          "It should be written as is, with a content length specified, and the encoding should be set to be x-www-form-urlencoded" : function(oa) {
+            var op= oa._createClient;
+            try {
+              var callbackCalled= false;
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                assert.equal(headers["Content-Type"], "application/x-www-form-urlencoded");
+                assert.equal(headers["Content-length"], 23);
+                return {
+                  write: function(data){
+                    callbackCalled= true;
+                    assert.equal(data, "foo=1%2C2%2C3&bar=1%2B2");
+                  },
+                  on: function() {},
+                  end: function() {
+                  }
+                };
+              };
+              var request= oa.post("http://foo.com/blah", "token", "token_secret", "foo=1%2C2%2C3&bar=1%2B2");
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+            }
+          }
+        },
+        "and a post_content_type is specified" : {
+          "It should be written as is, with a content length specified, and the encoding should be set to be as specified" : function(oa) {
+            var op= oa._createClient;
+            try {
+              var callbackCalled= false;
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                assert.equal(headers["Content-Type"], "unicorn/encoded");
+                assert.equal(headers["Content-length"], 23);
+                return {
+                  write: function(data){
+                    callbackCalled= true;
+                    assert.equal(data, "foo=1%2C2%2C3&bar=1%2B2");
+                  },
+                  on: function() {},
+                  end: function() {
+                  }
+                };
+              };
+              var request= oa.post("http://foo.com/blah", "token", "token_secret", "foo=1%2C2%2C3&bar=1%2B2", "unicorn/encoded");
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+            }
+          }
+        }
+      }
+    },
+    'GET' : {
+      'if no callback is passed' : {
+        'it should return a request object': function(oa) {
+          var request= oa.get("http://foo.com/blah", "token", "token_secret");
+          assert.isObject(request);
+          assert.equal(request.method, "GET");
+          request.end();
+        }
+      },
+      'if a callback is passed' : {
+        "it should call the internal request's end method and return nothing": function(oa) {
+          var callbackCalled= false;
+          var op= oa._createClient;
+          try {
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              return {
+                on: function() {},
+                end: function() {
+                  callbackCalled= true;
+                }
+              };
+            };
+            var request= oa.get("http://foo.com/blah", "token", "token_secret", function(e,d) {});
+            assert.equal(callbackCalled, true);
+            assert.isUndefined(request);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      },
+    },
+    'PUT' : {
+      'if no callback is passed' : {
+        'it should return a request object': function(oa) {
+          var request= oa.put("http://foo.com/blah", "token", "token_secret", "BLAH", "text/plain");
+          assert.isObject(request);
+          assert.equal(request.method, "PUT");
+          request.end();
+        }
+      },
+      'if a callback is passed' : {
+        "it should call the internal request's end method and return nothing": function(oa) {
+          var callbackCalled= 0;
+          var op= oa._createClient;
+          try {
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              return {
+                on: function() {},
+                write: function(data) {
+                  callbackCalled++;
+                },
+                end: function() {
+                  callbackCalled++;
+                }
+              };
+            };
+            var request= oa.put("http://foo.com/blah", "token", "token_secret", "BLAH", "text/plain", function(e,d){});
+            assert.equal(callbackCalled, 2);
+            assert.isUndefined(request);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      },
+      'if the post_body is a buffer' : {
+        "It should be passed through as is, and the original content-type (if specified) should be passed through": function(oa) {
+          var op= oa._createClient;
+          try {
+            var callbackCalled= false;
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              assert.equal(headers["Content-Type"], "image/jpeg");
+              return {
+                write: function(data){
+                  callbackCalled= true;
+                  assert.equal(data.length, 4);
+                },
+                on: function() {},
+                end: function() {
+                }
+              };
+            };
+            var request= oa.put("http://foo.com/blah", "token", "token_secret", new Buffer([10,20,30,40]), "image/jpeg");
+            assert.equal(callbackCalled, true);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        },
+        "It should be passed through as is, and no content-type is specified.": function(oa) {
+          //Should probably actually set application/octet-stream, but to avoid a change in behaviour
+          // will just document (here) that the library will set it to application/x-www-form-urlencoded
+          var op= oa._createClient;
+          try {
+            var callbackCalled= false;
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              assert.equal(headers["Content-Type"], "application/x-www-form-urlencoded");
+              return {
+                write: function(data){
+                  callbackCalled= true;
+                  assert.equal(data.length, 4);
+                },
+                on: function() {},
+                end: function() {
+                }
+              };
+            };
+            var request= oa.put("http://foo.com/blah", "token", "token_secret", new Buffer([10,20,30,40]));
+            assert.equal(callbackCalled, true);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      },
+      'if the post_body is not a string' : {
+        "It should be url encoded and the content type set to be x-www-form-urlencoded" : function(oa) {
+          var op= oa._createClient;
+          try {
+            var callbackCalled= false;
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              assert.equal(headers["Content-Type"], "application/x-www-form-urlencoded");
+              return {
+                write: function(data) {
+                  callbackCalled= true;
+                  assert.equal(data, "foo=1%2C2%2C3&bar=1%2B2");
+                }
+              };
+            };
+            var request= oa.put("http://foo.com/blah", "token", "token_secret", {"foo":"1,2,3", "bar":"1+2"});
+            assert.equal(callbackCalled, true);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      },
+      'if the post_body is a string' : {
+        "and no post_content_type is specified" : {
+          "It should be written as is, with a content length specified, and the encoding should be set to be x-www-form-urlencoded" : function(oa) {
+            var op= oa._createClient;
+            try {
+              var callbackCalled= false;
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                assert.equal(headers["Content-Type"], "application/x-www-form-urlencoded");
+                assert.equal(headers["Content-length"], 23);
+                return {
+                  write: function(data) {
+                    callbackCalled= true;
+                    assert.equal(data, "foo=1%2C2%2C3&bar=1%2B2");
+                  }
+                };
+              };
+              var request= oa.put("http://foo.com/blah", "token", "token_secret", "foo=1%2C2%2C3&bar=1%2B2");
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+            }
+          }
+        },
+        "and a post_content_type is specified" : {
+          "It should be written as is, with a content length specified, and the encoding should be set to be as specified" : function(oa) {
+            var op= oa._createClient;
+            try {
+              var callbackCalled= false;
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                assert.equal(headers["Content-Type"], "unicorn/encoded");
+                assert.equal(headers["Content-length"], 23);
+                return {
+                  write: function(data) {
+                    callbackCalled= true;
+                    assert.equal(data, "foo=1%2C2%2C3&bar=1%2B2");
+                  }
+                };
+              };
+              var request= oa.put("http://foo.com/blah", "token", "token_secret", "foo=1%2C2%2C3&bar=1%2B2", "unicorn/encoded");
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+            }
+          }
+        }
+      }
+    },
+    'DELETE' : {
+      'if no callback is passed' : {
+        'it should return a request object': function(oa) {
+          var request= oa.delete("http://foo.com/blah", "token", "token_secret");
+          assert.isObject(request);
+          assert.equal(request.method, "DELETE");
+          request.end();
+        }
+      },
+      'if a callback is passed' : {
+        "it should call the internal request's end method and return nothing": function(oa) {
+          var callbackCalled= false;
+          var op= oa._createClient;
+          try {
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              return {
+                on: function() {},
+                end: function() {
+                  callbackCalled= true;
+                }
+              };
+            };
+            var request= oa.delete("http://foo.com/blah", "token", "token_secret", function(e,d) {});
+            assert.equal(callbackCalled, true);
+            assert.isUndefined(request);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      }
+    },
+    'Request With a Callback' : {
+      'and a 200 response code is received' : {
+        'it should callback successfully' : function(oa) {
+          var op= oa._createClient;
+          var callbackCalled = false;
+          try {
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              return new DummyRequest( new DummyResponse(200) );
+            };
+            oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(error) {
+              // callback
+              callbackCalled= true;
+              assert.equal(error, undefined);
+            });
+            assert.equal(callbackCalled, true);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      },
+      'and a 210 response code is received' : {
+        'it should callback successfully' : function(oa) {
+          var op= oa._createClient;
+          var callbackCalled = false;
+          try {
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              return new DummyRequest( new DummyResponse(210) );
+            };
+            oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(error) {
+              // callback
+              callbackCalled= true;
+              assert.equal(error, undefined);
+            });
+            assert.equal(callbackCalled, true);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      },
+      'And A 301 redirect is received' : {
+        'and there is a location header' : {
+          'it should (re)perform the secure request but with the new location' : function(oa) {
+            var op= oa._createClient;
+            var psr= oa._performSecureRequest;
+            var responseCounter = 1;
+            var callbackCalled = false;
+            var DummyResponse =function() {
+              if( responseCounter == 1 ){
+                this.statusCode= 301;
+                this.headers= {location:"http://redirectto.com"};
+                responseCounter++;
+              }
+              else {
+                this.statusCode= 200;
+              }
+            };
+            DummyResponse.prototype= events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding= function() {};
+
+            try {
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                return new DummyRequest( new DummyResponse() );
+              };
+              oa._performSecureRequest= function( oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback ) {
+                if( responseCounter == 1 ) {
+                  assert.equal(url, "http://originalurl.com");
+                }
+                else {
+                  assert.equal(url, "http://redirectto.com");
+                }
+                return psr.call(oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback );
+              };
+
+              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function() {
+                // callback
+                assert.equal(responseCounter, 2);
+                callbackCalled= true;
+              });
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+              oa._performSecureRequest= psr;
+            }
+          }
+        },
+        'but there is no location header' : {
+          'it should execute the callback, passing the HTTP Response code' : function(oa) {
+            var op= oa._createClient;
+            var callbackCalled = false;
+            try {
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                return new DummyRequest( new DummyResponse(301) );
+              };
+              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(error) {
+                // callback
+                assert.equal(error.statusCode, 301);
+                callbackCalled= true;
+              });
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+            }
+          }
+        },
+        'and followRedirect is true' : {
+          'it should (re)perform the secure request but with the new location' : function(oa) {
+            var op= oa._createClient;
+            var psr= oa._performSecureRequest;
+            var responseCounter = 1;
+            var callbackCalled = false;
+            var DummyResponse =function() {
+              if( responseCounter == 1 ){
+                this.statusCode= 301;
+                this.headers= {location:"http://redirectto.com"};
+                responseCounter++;
+              }
+              else {
+                this.statusCode= 200;
+              }
+            };
+            DummyResponse.prototype= events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding = function() {};
+
+            try {
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                return new DummyRequest( new DummyResponse() );
+              };
+              oa._performSecureRequest= function( oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback ) {
+                if( responseCounter == 1 ) {
+                  assert.equal(url, "http://originalurl.com");
+                }
+                else {
+                  assert.equal(url, "http://redirectto.com");
+                }
+                return psr.call(oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback );
+              };
+
+              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function() {
+                // callback
+                assert.equal(responseCounter, 2);
+                callbackCalled= true;
+              });
+              assert.equal(callbackCalled, true)
+            }
+            finally {
+              oa._createClient= op;
+              oa._performSecureRequest= psr;
+            }
+          }
+        },
+        'and followRedirect is false' : {
+          'it should not perform the secure request with the new location' : function(oa) {
+            var op= oa._createClient;
+            oa.setClientOptions({ followRedirects: false });
+            var DummyResponse =function() {
+              this.statusCode= 301;
+              this.headers= {location:"http://redirectto.com"};
+            }
+            DummyResponse.prototype= events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding= function() {}
+
+            try {
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                return new DummyRequest( new DummyResponse() );
+              }
+              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(res, data, response) {
+                // callback
+                assert.equal(res.statusCode, 301);
+              });
+            }
+            finally {
+              oa._createClient= op;
+              oa.setClientOptions({followRedirects:true});
+            }
+          }
+        }
+      },
+      'And A 302 redirect is received' : {
+        'and there is a location header' : {
+          'it should (re)perform the secure request but with the new location' : function(oa) {
+            var op= oa._createClient;
+            var psr= oa._performSecureRequest;
+            var responseCounter = 1;
+            var callbackCalled = false;
+            var DummyResponse =function() {
+              if( responseCounter == 1 ){
+                this.statusCode= 302;
+                this.headers= {location:"http://redirectto.com"};
+                responseCounter++;
+              } else {
+                this.statusCode= 200;
+              }
+            };
+            DummyResponse.prototype= events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding = function() {};
+
+            try {
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                return new DummyRequest( new DummyResponse() );
+              }
+              oa._performSecureRequest= function( oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback ) {
+                if( responseCounter == 1 ) {
+                  assert.equal(url, "http://originalurl.com");
+                } else {
+                  assert.equal(url, "http://redirectto.com");
+                }
+                return psr.call(oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback )
+              }
+
+              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function() {
+                // callback
+                assert.equal(responseCounter, 2);
+                callbackCalled = true;
+              });
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+              oa._performSecureRequest= psr;
+            }
+          }
+        },
+        'but there is no location header' : {
+          'it should execute the callback, passing the HTTP Response code' : function(oa) {
+            var op= oa._createClient;
+            var callbackCalled = false;
+            try {
+              oa._createClient = function(port, hostname, method, path, headers, sshEnabled ) {
+                return new DummyRequest(new DummyResponse(302));
+              };
+              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(error) {
+                // callback
+                assert.equal(error.statusCode, 302);
+                callbackCalled = true;
+              });
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+            }
+          }
+        },
+        'and followRedirect is true' : {
+          'it should (re)perform the secure request but with the new location' : function(oa) {
+            var op= oa._createClient;
+            var psr= oa._performSecureRequest;
+            var responseCounter = 1;
+            var callbackCalled = false;
+            var DummyResponse = function() {
+              if (responseCounter == 1) {
+                this.statusCode= 302;
+                this.headers= {location:"http://redirectto.com"};
+                responseCounter++;
+              } else {
+                this.statusCode= 200;
+              }
+            };
+            DummyResponse.prototype= events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding = function() {};
+
+            try {
+              oa._createClient = function(port, hostname, method, path, headers, sshEnabled) {
+                return new DummyRequest(new DummyResponse());
+              };
+              oa._performSecureRequest = function(oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback) {
+                if (responseCounter == 1) {
+                  assert.equal(url, "http://originalurl.com");
+                } else {
+                  assert.equal(url, "http://redirectto.com");
+                }
+                return psr.call(oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type, callback);
+              };
+
+              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function() {
+                // callback
+                assert.equal(responseCounter, 2);
+                callbackCalled = true;
+              });
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+              oa._performSecureRequest= psr;
+            }
+          }
+        },
+        'and followRedirect is false' : {
+          'it should not perform the secure request with the new location' : function(oa) {
+            var op= oa._createClient;
+            oa.setClientOptions({ followRedirects: false });
+            var DummyResponse =function() {
+              this.statusCode= 302;
+              this.headers= {location:"http://redirectto.com"};
+            };
+            DummyResponse.prototype= events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding= function() {};
+
+            try {
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                return new DummyRequest( new DummyResponse() );
+              };
+              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(res, data, response) {
+                // callback
+                assert.equal(res.statusCode, 302);
+              });
+            }
+            finally {
+              oa._createClient= op;
+              oa.setClientOptions({followRedirects:true});
+            }
+          }
+        }
+      }
+    }
+  }
+}).export(module);

--- a/tests/oauthpromise-tests.js
+++ b/tests/oauthpromise-tests.js
@@ -893,20 +893,20 @@ vows.describe('OAuth').addBatch({
             }
           }
         },
-        'and followRedirect is false' : {
-          'it should not perform the secure request with the new location' : function(oa) {
+        'and followRedirect is false': {
+          'it should not perform the secure request with the new location': function(oa) {
             var op = oa._oa._createClient;
             oa.setClientOptions({ followRedirects: false });
-            var DummyResponse =function() {
-              this.statusCode= 301;
-              this.headers= {location:"http://redirectto.com"};
+            var DummyResponse = function() {
+              this.statusCode = 301;
+              this.headers = { location: 'http://redirectto.com' };
             };
-            DummyResponse.prototype= events.EventEmitter.prototype;
-            DummyResponse.prototype.setEncoding= function() {};
+            DummyResponse.prototype = events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding = function() {};
 
             try {
-                return new DummyRequest( new DummyResponse() );
               oa._oa._createClient = function(port, hostname, method, path, headers, sshEnabled) {
+                return new DummyRequest(new DummyResponse());
               };
               oa._oa._performSecureRequest('token', 'token_secret', 'POST', 'http://originalurl.com', { 'scope': 'foobar,1,2' }, null, null, function(res, data, response) {
                 assert.equal(res.statusCode, 301);

--- a/tests/oauthpromise-tests.js
+++ b/tests/oauthpromise-tests.js
@@ -895,7 +895,7 @@ vows.describe('OAuth').addBatch({
         },
         'and followRedirect is false' : {
           'it should not perform the secure request with the new location' : function(oa) {
-            var op= oa._createClient;
+            var op = oa._oa._createClient;
             oa.setClientOptions({ followRedirects: false });
             var DummyResponse =function() {
               this.statusCode= 301;
@@ -905,14 +905,14 @@ vows.describe('OAuth').addBatch({
             DummyResponse.prototype.setEncoding= function() {};
 
             try {
-              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
                 return new DummyRequest( new DummyResponse() );
+              oa._oa._createClient = function(port, hostname, method, path, headers, sshEnabled) {
               };
-              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', { "scope": "foobar,1,2" }, null, null, function(res, data, response) {
+              oa._oa._performSecureRequest('token', 'token_secret', 'POST', 'http://originalurl.com', { 'scope': 'foobar,1,2' }, null, null, function(res, data, response) {
                 assert.equal(res.statusCode, 301);
               });
             } finally {
-              oa._createClient = op;
+              oa._oa._createClient = op;
               oa.setClientOptions({ followRedirects: true });
             }
           }

--- a/tests/shared.js
+++ b/tests/shared.js
@@ -1,26 +1,31 @@
 var events = require('events');
 
-exports.DummyResponse = function( statusCode ) {
-    this.statusCode= statusCode;
-    this.headers= {};
-}
-exports.DummyResponse.prototype= events.EventEmitter.prototype;
-exports.DummyResponse.prototype.setEncoding= function() {}
+exports.DummyResponse = function(statusCode) {
+  this.statusCode = statusCode;
+  this.headers = {};
+};
 
-exports.DummyRequest =function( response ) {
-  this.response=  response;
-  this.responseSent= false;
-}
-exports.DummyRequest.prototype= events.EventEmitter.prototype;
-exports.DummyRequest.prototype.write= function(post_body){}
-exports.DummyRequest.prototype.write= function(post_body){
-  this.responseSent= true;
-  this.emit('response',this.response);
-}
-exports.DummyRequest.prototype.end= function(){
-  if(!this.responseSent) {
-    this.responseSent= true;
+exports.DummyResponse.prototype = events.EventEmitter.prototype;
+
+exports.DummyResponse.prototype.setEncoding = function() {
+};
+
+exports.DummyRequest = function(response) {
+  this.response = response;
+  this.responseSent = false;
+};
+
+exports.DummyRequest.prototype = events.EventEmitter.prototype;
+
+exports.DummyRequest.prototype.write = function(postBody) {
+  this.responseSent = true;
+  this.emit('response', this.response);
+};
+
+exports.DummyRequest.prototype.end = function() {
+  if (!this.responseSent) {
+    this.responseSent = true;
     this.emit('response',this.response);
   }
   this.response.emit('end');
-}
+};


### PR DESCRIPTION
Closes #4 

* OAuth Promises
* OAuth2 Promises
* Examples that use promises
* Existing tests for OAuth and OAuth2 ported to ensure backwards compatibility with Promise wrapper objects

## Notes

Some more testing is definitely needed because I have a feeling we will need custom wrappers for the post/get/put requests in OAuth to make sure the promises are receiving the right objects. For example in OAuth2 Promises the first `then` receiver will receive just the data from the response, but in OAuth2 something else may happen such as receiving the request and response object. The node-oauth API for callbacks always passes `accessToken`, `refreshToken` and `response` which we aren't conforming too.