### PR TITLE
Add a library that use node-oauth-libre

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,6 +8,10 @@ Tested against Twitter (http://twitter.com), term.ie (http://term.ie/oauth/examp
 
 Also provides rudimentary OAuth2 support, tested against facebook, github, foursquare, google and Janrain.   For more complete usage examples please take a look at connect-auth (http://github.com/ciaranj/connect-auth)
 
+## Related Libraries
+
+- [pasport-oauth2-libre](https://github.com/caco0516/passport-oauth2-libre) Passport OAuth2 Strategy using node-oauth-libre.
+
 ## License and Copyright
 
 **This code is covered under the GNU GPL version 3 or later with parts of the code also covered by the MIT license.**

--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ Also provides rudimentary OAuth2 support, tested against facebook, github, fours
 
 ## Related Libraries
 
-- [pasport-oauth2-libre](https://github.com/caco0516/passport-oauth2-libre) Passport OAuth2 Strategy using node-oauth-libre.
+- [passport-oauth2-libre](https://github.com/caco0516/passport-oauth2-libre) Passport OAuth2 Strategy using node-oauth-libre.
 
 ## License and Copyright
 


### PR DESCRIPTION
Hi @omouse i just want to add my own strategy implementation using your library , I think this will help people to start using passportjs and node-outh-libre at same time.