### PR TITLE
Just added Authorization header for POST token by OAuth 2.0 specification

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -22,7 +22,8 @@ var querystring= require('querystring'),
     https= require('https'),
     http= require('http'),
     URL= require('url'),
-    OAuthUtils= require('./_utils');
+    OAuthUtils= require('./_utils'),
+    Buffer = require('buffer').Buffer;
 
 exports.OAuth2= function(clientId, clientSecret, baseSite, authorizePath, accessTokenPath, customHeaders) {
   this._clientId= clientId;
@@ -188,7 +189,8 @@ exports.OAuth2.prototype.getOAuthAccessToken= function(code, params, callback) {
 
   var post_data= querystring.stringify( params );
   var post_headers= {
-       'Content-Type': 'application/x-www-form-urlencoded'
+       'Content-Type': 'application/x-www-form-urlencoded',
+       'Authorization': 'Basic ' + Buffer.from(this._clientId + ':' + this._clientSecret).toString('base64')
    };
 
 

--- a/tests/oauth2tests.js
+++ b/tests/oauth2tests.js
@@ -66,6 +66,19 @@ vows.describe('OAuth2').addBatch({
               assert.equal( refresh_token, "refresh");
             });
         },
+          'we should correctly send Authorization header encoded Base64 for token request': function (oa) {
+              oa._request= function( method, url, postHeaders, bar, bleh, callback) {
+                  var authHeaderContent = postHeaders.Authorization;
+                  assert.isNotNull(authHeaderContent, "Authorization header for token request must to be present.");
+                  var headerSplit = authHeaderContent.split(' ');
+                  assert.equal("Basic", headerSplit[0]);
+                  var decodedAuthHeader = Buffer.from(headerSplit[1], 'base64').toString('ascii');
+                  assert.equal(decodedAuthHeader,"clientId:clientSecret");
+                  callback(null, "access_token=access&refresh_token=refresh");
+              };
+              oa.getOAuthAccessToken("", {}, function(error, access_token, refresh_token) { });
+          }
+        ,
         'we should not include access token in both querystring and headers (favours headers if specified)': function (oa) {
             oa._request = new OAuth2("clientId", "clientSecret")._request.bind(oa);
             oa._executeRequest= function( http_library, options, post_body, callback) {


### PR DESCRIPTION
I added this **Authorization Basic base64data** to post headers , this because OAuth 2.0 specification. I need this update to NPM modulo because I develop a OAuth2 server but I need this implementation to use it in my next express-passportjs based application. You can find more information in here [OAuth 2.0 IETF](https://tools.ietf.org/html/rfc6749#section-4.1.3).

Regards.

PD: I really appreciate your job. 👍  