### PR TITLE
 move extra params to function call

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -487,8 +487,7 @@ exports.OAuth.prototype.setClientOptions= function(options) {
   this._clientOptions= mergedOptions;
 };
 
-exports.OAuth.prototype.getOAuthAccessToken= function(oauth_token, oauth_token_secret, oauth_verifier,  callback) {
-  var extraParams= {};
+exports.OAuth.prototype.getOAuthAccessToken= function(oauth_token, oauth_token_secret, oauth_verifier,  callback, extraParams = {}) {
   if( typeof oauth_verifier == "function" ) {
     callback= oauth_verifier;
   } else {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -487,7 +487,10 @@ exports.OAuth.prototype.setClientOptions= function(options) {
   this._clientOptions= mergedOptions;
 };
 
-exports.OAuth.prototype.getOAuthAccessToken= function(oauth_token, oauth_token_secret, oauth_verifier,  callback, extraParams = {}) {
+exports.OAuth.prototype.getOAuthAccessToken= function(oauth_token, oauth_token_secret, oauth_verifier,  callback, extraParams) {
+  if(!extraParams) {
+	  var extraParams = {};
+  }		
   if( typeof oauth_verifier == "function" ) {
     callback= oauth_verifier;
   } else {


### PR DESCRIPTION
In order to make the access token function more flexible in case we need to send it extra params , i moved the initialization of the variable to the function call, if anyone is using the function he will not be affected since it's added at the end and initialized, whoever wants to use It he can now send an object as extra params