### PR TITLE
move extraParams to getOAuthAccessToken parameters

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -636,9 +636,10 @@ exports.OAuth.prototype.setClientOptions= function(options) {
  * @param {string} oauth_token_secret
  * @param {string} oauth_verifier
  * @param {OAuth.requestCallback} callback
+ * @param {Object} [extraParams] Extra parameters to send with the request
  */
-exports.OAuth.prototype.getOAuthAccessToken= function(oauth_token, oauth_token_secret, oauth_verifier,  callback) {
-  var extraParams= {};
+exports.OAuth.prototype.getOAuthAccessToken= function(oauth_token, oauth_token_secret, oauth_verifier, callback, extraParams) {
+  var extraParams = extraParams || {};
   if( typeof oauth_verifier == "function" ) {
     callback= oauth_verifier;
   } else {

--- a/tests/oauthtests.js
+++ b/tests/oauthtests.js
@@ -225,7 +225,17 @@ vows.describe('OAuth').addBatch({
           oa.setClientOptions({});
           oa.getOAuthAccessToken(function() {});
           assert.equal(oa.requestArguments[2], "POST");
-        }
+        },
+      '': function(oa) {
+        var extraParams = { extra: 1, params: 2 };
+        oa.getOAuthAccessToken(null, null, null, function callback() { }, extraParams);
+        assert.ok('extra' in oa.requestArguments[4]);
+        assert.ok('params' in oa.requestArguments[4]);
+        assert.ok('oauth_verifier' in oa.requestArguments[4]);
+        assert.equal(oa.requestArguments[4].extra, extraParams.extra);
+        assert.equal(oa.requestArguments[4].params, extraParams.params);
+        assert.equal(oa.requestArguments[4].oauth_verifier, null);
+      }
     },
     'When get authorization header' : {
         topic: function() {


### PR DESCRIPTION
replaces #23 

>In order to make the access token function more flexible in case we need to send it extra params , i moved the initialization of the variable to the function call, if anyone is using the function he will not be affected since it's added at the end and initialized, whoever wants to use It he can now send an object as extra params