### PR TITLE
Allow content-type header to be set when making requests

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -93,7 +93,7 @@ Example of using OAuth 1.0 with the Twitter API.
 
 ```javascript
 describe('OAuth1.0',function(){
-  var OAuth = require('oauth');
+  var OAuth = require('oauth-libre');
 
   it('tests trends Twitter API v1.1',function(done){
     var oauth = new OAuth.OAuth(
@@ -105,6 +105,7 @@ describe('OAuth1.0',function(){
       null,
       'HMAC-SHA1'
     );
+    oauth.setDefaultContentType('application/json');
     oauth.get(
       'https://api.twitter.com/1.1/trends/place.json?id=23424977',
       'your user token for this app', //test user token
@@ -123,7 +124,7 @@ describe('OAuth1.0',function(){
 ### Usage
 
 ```javascript
-var OAuth2 = require('oauth').OAuth2;
+var OAuth2 = require('oauth-libre').OAuth2;
 
 console.log("Login here to get an authorization code: " + oauth2.getAuthorizeUrl());
 
@@ -188,7 +189,7 @@ This event is emitted after the request has been executed, we receive informatio
 
 ```javascript
 describe('OAuth2',function() {
-  var OAuth = require('oauth');
+  var OAuth = require('oauth-libre');
 
    it('gets bearer token', function(done){
      var OAuth2 = OAuth.OAuth2;

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -60,7 +60,11 @@ exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, vers
     throw new Error("Un-supported signature method: " + signatureMethod )
   this._signatureMethod= signatureMethod;
   this._nonceSize= nonceSize || 32;
-  this._contentType = 'application/x-www-form-urlencoded';
+  this._defaultContentType = 'application/x-www-form-urlencoded';
+  if (customHeaders && customHeaders['Content-Type']) {
+      this._defaultContentType = customHeaders['Content-Type'];
+      delete customHeaders['Content-Type'];
+  }
   this._headers= customHeaders || {"Accept" : "*/*",
                                    "Connection" : "close",
                                    "User-Agent" : "Node authentication"}
@@ -481,7 +485,7 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
   var orderedParameters= this._prepareParameters(oauth_token, oauth_token_secret, method, url, extra_params);
 
   if( !post_content_type ) {
-    post_content_type= this._contentType;
+    post_content_type= this._defaultContentType;
   }
   var parsedUrl= URL.parse( url, false );
   if( parsedUrl.protocol == "http:" && !parsedUrl.port ) parsedUrl.port= 80;
@@ -629,8 +633,8 @@ exports.OAuth.prototype.setClientOptions= function(options) {
 
   this._clientOptions= mergedOptions;
 };
-exports.OAuth.prototype.setContentType= function(contentType) {
-  this._contentType = contentType;
+exports.OAuth.prototype.setDefaultContentType= function(contentType) {
+  this._defaultContentType = contentType;
 };
 
 /**

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -60,6 +60,7 @@ exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, vers
     throw new Error("Un-supported signature method: " + signatureMethod )
   this._signatureMethod= signatureMethod;
   this._nonceSize= nonceSize || 32;
+  this._contentType = 'application/x-www-form-urlencoded';
   this._headers= customHeaders || {"Accept" : "*/*",
                                    "Connection" : "close",
                                    "User-Agent" : "Node authentication"}
@@ -480,7 +481,7 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
   var orderedParameters= this._prepareParameters(oauth_token, oauth_token_secret, method, url, extra_params);
 
   if( !post_content_type ) {
-    post_content_type= "application/x-www-form-urlencoded";
+    post_content_type= this._contentType;
   }
   var parsedUrl= URL.parse( url, false );
   if( parsedUrl.protocol == "http:" && !parsedUrl.port ) parsedUrl.port= 80;
@@ -627,6 +628,9 @@ exports.OAuth.prototype.setClientOptions= function(options) {
   }
 
   this._clientOptions= mergedOptions;
+};
+exports.OAuth.prototype.setContentType= function(contentType) {
+  this._contentType = contentType;
 };
 
 /**

--- a/tests/oauthtests.js
+++ b/tests/oauthtests.js
@@ -349,6 +349,47 @@ vows.describe('OAuth').addBatch({
             oa._createClient= op;
           }
         }
+      },
+      'Setting content-type on OAuth object should set content-type on request to value passed to setContentType': function (oa) {
+        var op = oa._createClient;
+        var opContentType = oa._contentType;
+        var expectedContentType = 'application/json';
+        oa.setContentType(expectedContentType);
+        var createClientHeaders = null;
+        try {
+          oa._createClient = function (port, hostname, method, path, headers, sshEnabled) {
+            createClientHeaders = headers;
+            return {
+              write: function (post_body) {
+              }
+            };
+          };
+          oa._performSecureRequest("token", "token_secret", 'POST', 'http://foo.com/protected_resource', {"scope": "foobar,1,2"});
+          assert.equal(createClientHeaders['Content-Type'], expectedContentType);
+        }
+        finally {
+          oa._createClient = op;
+          oa._contentType = opContentType;
+        }
+      },
+      'Not setting content-type on OAuth object should set content-type on request to application/x-www-form-urlencoded': function (oa) {
+        var createClientHeaders = null;
+        var op = oa._createClient;
+        try {
+          oa._createClient = function (port, hostname, method, path, headers, sshEnabled) {
+            createClientHeaders = headers;
+            return {
+              write: function (post_body) {
+              }
+            };
+          };
+          oa._performSecureRequest("token", "token_secret", 'POST', 'http://foo.com/protected_resource', {"scope": "foobar,1,2"});
+          assert.equal(createClientHeaders['Content-Type'], 'application/x-www-form-urlencoded');
+        }
+        finally {
+          oa.setContentType(null);
+          oa._createClient = op;
+        }
       }
     },
     'When performing a secure' : {


### PR DESCRIPTION
Right now, when creating oauth requests with `get` and `delete`, the content-type header is always set to application/x-www-form-urlencoded. This PR allows changing the default content-type header set by an oauth connection without having to overload the constructor.

Originally created to solve https://github.com/ciaranj/node-oauth/issues/331